### PR TITLE
Fixes #9 (Constants whose id goes beyond 16/32/64 will not deserialize)

### DIFF
--- a/src/number.luau
+++ b/src/number.luau
@@ -76,7 +76,7 @@ local function numSerializer(value: number, buf: buffer, pos: number, size: numb
 		if newSize == 1 then
 			buffer.writeu8(buf, pos, cachedConstant + 99)
 		else
-			local constVal = cachedConstant - 64
+			local constVal = cachedConstant - 32
 			buffer.writeu8(buf, pos, 132 + (constVal // 256) )
 			buffer.writeu8(buf, pos+1, constVal)
 		end
@@ -158,14 +158,14 @@ local function numDeserializer(buf: buffer, pos: number): (number?, number)
 	
 	if id > 99 then
 		local cachedId = if id > 131 then
-				(id - 131) * 256 + 64
+				(id - 132) * 256 + 32 + buffer.readu8(buf, pos + 1)
 			else
-				id - 105
+				id - 99
 
 		local cachedConstant: number? = READ[cachedId]
 		if cachedConstant then
 			return cachedConstant, 
-				pos + (if cachedId > 64 then 2 else 1)
+				pos + (if cachedId > 32 then 2 else 1)
 		end
 	end
 

--- a/src/string.luau
+++ b/src/string.luau
@@ -90,7 +90,7 @@ local function strDeserializer(buf: buffer, pos: number): (string?, number)
 
 	if id > 18 then
 		local cachedId = if id > 82 then
-				(id - 82) * 256 + 64
+				(id - 83) * 256 + 64 + buffer.readu8(buf, pos + 1)
 			else
 				id - 18
 

--- a/src/userdata.luau
+++ b/src/userdata.luau
@@ -33,7 +33,7 @@ local Userdata = {
 			if newSize == 1 then
 				buffer.writeu8(buf, pos, cachedConstant + 203)
 			else
-				local constVal = cachedConstant - 64
+				local constVal = cachedConstant - 16
 				buffer.writeu8(buf, pos, 220 + (constVal // 256) )
 				buffer.writeu8(buf, pos+1, constVal)
 			end
@@ -67,14 +67,14 @@ local Userdata = {
 
 		if id > 203 then
 				local cachedId = if id > 219 then
-					(id - 219) * 256 + 64
+					(id - 220) * 256 + 16 + buffer.readu8(buf, pos + 1)
 				else
 					id - 203
 
 			local cachedConstant = READ[cachedId]
 			if cachedConstant then
 				return cachedConstant, 
-					pos + (if cachedId > 64 then 2 else 1)
+					pos + (if cachedId > 16 then 2 else 1)
 			end
 		end
 

--- a/src/vector.luau
+++ b/src/vector.luau
@@ -98,7 +98,7 @@ local function vecSerializer(value: vector, buf: buffer, pos: number, size: numb
 		if newSize == 1 then
 			buffer.writeu8(buf, pos, cachedConstant + 157)
 		else
-			local constVal = cachedConstant - 64
+			local constVal = cachedConstant - 32
 			buffer.writeu8(buf, pos, 190 + (constVal // 256) )
 			buffer.writeu8(buf, pos+1, constVal)
 		end
@@ -254,14 +254,14 @@ local function vecDeserializer(buf: buffer, pos: number): (vector?, number)
 
 	if id > 157 then
 		local cachedId = if id > 189 then
-				(id - 189) * 256 + 64
+				(id - 190) * 256 + 32 + buffer.readu8(buf, pos + 1)
 			else
 				id - 157
 		
 		local cachedConstant: vector? = READ[cachedId]
 		if cachedConstant then
 			return cachedConstant, 
-				pos + (if cachedId > 64 then 2 else 1)
+				pos + (if cachedId > 32 then 2 else 1)
 		end
 	end
 


### PR DESCRIPTION
Number serialization / deserialization now handles constants whose ids surpass 32.  Ids below 32 now properly deserialize as well.

String deserialization now handles constants whose ids surpass 64 properly.

Vector serialization and deserialization now handles constants whose ids surpass 32.

Userdata serialization and deserialization now handles constants whose ids surpass 16.