### PR TITLE
Simplify inflate

### DIFF
--- a/src/boolean.luau
+++ b/src/boolean.luau
@@ -9,9 +9,7 @@ local inflate = require("./inflate")
 ]]--
 return {
 	serialize = function(value: boolean, buf: buffer, pos: number, size: number)
-		if not buf then
-			buf, size = buffer.create(1), 1
-		elseif pos + 1 > size then
+		if not buf or pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 

--- a/src/boolean.luau
+++ b/src/boolean.luau
@@ -9,7 +9,7 @@ local inflate = require("./inflate")
 ]]--
 return {
 	serialize = function(value: boolean, buf: buffer, pos: number, size: number)
-		if not buf or pos + 1 > size then
+		if pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 

--- a/src/buffer.luau
+++ b/src/buffer.luau
@@ -15,7 +15,7 @@ return {
 		local len = buffer.len(value)
 
 		if len == 0 then
-			if not buf or pos + 1 > size then
+			if pos + 1 > size then
 				buf, size = inflate(buf, pos + 1, size)
 			end
 			buffer.writeu8(buf, pos, EMPTY)
@@ -31,7 +31,7 @@ return {
 			else
 				5
 		
-		if not buf or pos + len + newSize > size then
+		if pos + len + newSize > size then
 			buf, size = inflate(buf, pos + len + newSize, size)
 		end
 		buffer.writeu8(buf, pos, 2 + newSize)

--- a/src/buffer.luau
+++ b/src/buffer.luau
@@ -15,9 +15,7 @@ return {
 		local len = buffer.len(value)
 
 		if len == 0 then
-			if not buf then
-				buf, size = buffer.create(1), 1
-			elseif pos + 1 > size then
+			if not buf or pos + 1 > size then
 				buf, size = inflate(buf, pos + 1, size)
 			end
 			buffer.writeu8(buf, pos, EMPTY)
@@ -33,9 +31,7 @@ return {
 			else
 				5
 		
-		if not buf then
-			buf, size = buffer.create(len + newSize), len + newSize
-		elseif pos + len + newSize > size then
+		if not buf or pos + len + newSize > size then
 			buf, size = inflate(buf, pos + len + newSize, size)
 		end
 		buffer.writeu8(buf, pos, 2 + newSize)

--- a/src/inflate.luau
+++ b/src/inflate.luau
@@ -7,6 +7,10 @@
 ]]--
 @native
 local function inflate(data: buffer, minSize: number, oldSize: number)
+	if oldSize == 0 then
+		return buffer.create(minSize), minSize
+	end
+	
 	while minSize > oldSize do
 		oldSize *= 2
 	end

--- a/src/nil.luau
+++ b/src/nil.luau
@@ -9,7 +9,7 @@ local inflate = require("./inflate")
 ]]--
 return {
 	serialize = function(value: nil, buf: buffer, pos: number, size: number)
-		if not buf or pos + 1 > size then
+		if pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 

--- a/src/nil.luau
+++ b/src/nil.luau
@@ -9,9 +9,7 @@ local inflate = require("./inflate")
 ]]--
 return {
 	serialize = function(value: nil, buf: buffer, pos: number, size: number)
-		if not buf then
-			buf, size = buffer.create(1), 1
-		elseif pos + 1 > size then
+		if not buf or pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 

--- a/src/number.luau
+++ b/src/number.luau
@@ -35,19 +35,19 @@ local WRITE = {} -- 1 to 1055
 local function numSerializer(value: number, buf: buffer, pos: number, size: number)
 
 	if value == 0 then
-		if not buf or pos + 1 > size then
+		if pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, ZERO)
 		return buf, pos + 1, size
 	elseif value == 1 then
-		if not buf or pos + 1 > size then
+		if pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, ONE)
 		return buf, pos + 1, size
 	elseif value ~= value then
-		if not buf or pos + 1 > size then
+		if pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, NAN)
@@ -61,7 +61,7 @@ local function numSerializer(value: number, buf: buffer, pos: number, size: numb
 			else
 				2
 		
-		if not buf or pos + newSize > size then
+		if pos + newSize > size then
 			buf, size = inflate(buf, pos + newSize, size)
 		end
 
@@ -80,7 +80,7 @@ local function numSerializer(value: number, buf: buffer, pos: number, size: numb
 	if value % 1 ~= 0 or value > MAX_INT or value < MIN_INT then
 
 		if MAX_FLOAT < value or value < -MAX_FLOAT then
-			if not buf or pos + 9 > size then
+			if pos + 9 > size then
 				buf, size = inflate(buf, pos + 9, size)
 			end
 			buffer.writeu8(buf, pos, DOUBLE)
@@ -91,7 +91,7 @@ local function numSerializer(value: number, buf: buffer, pos: number, size: numb
 		-- Ensures that the output WILL be the same as the input
 		-- even if it results in a slower path
 		if (vecX * value).x == value then
-			if not buf or pos + 5 > size then
+			if pos + 5 > size then
 				buf, size = inflate(buf, pos + 5, size)
 			end
 			buffer.writeu8(buf, pos, FLOAT)
@@ -99,7 +99,7 @@ local function numSerializer(value: number, buf: buffer, pos: number, size: numb
 			return buf, pos + 5, size
 		end
 		
-		if not buf or pos + 9 > size then
+		if pos + 9 > size then
 			buf, size = inflate(buf, pos + 9, size)
 		end
 		buffer.writeu8(buf, pos, DOUBLE)
@@ -116,7 +116,7 @@ local function numSerializer(value: number, buf: buffer, pos: number, size: numb
 		else
 			5
 	
-	if not buf or pos + newSize > size then
+	if pos + newSize > size then
 		buf, size = inflate(buf, pos + newSize, size)
 	end
 	buffer.writeu8(buf, pos, ZERO + newSize)

--- a/src/number.luau
+++ b/src/number.luau
@@ -35,25 +35,19 @@ local WRITE = {} -- 1 to 1055
 local function numSerializer(value: number, buf: buffer, pos: number, size: number)
 
 	if value == 0 then
-		if not buf then
-			buf, size = buffer.create(1), 1
-		elseif pos + 1 > size then
+		if not buf or pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, ZERO)
 		return buf, pos + 1, size
 	elseif value == 1 then
-		if not buf then
-			buf, size = buffer.create(1), 1
-		elseif pos + 1 > size then
+		if not buf or pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, ONE)
 		return buf, pos + 1, size
 	elseif value ~= value then
-		if not buf then
-			buf, size = buffer.create(1), 1
-		elseif pos + 1 > size then
+		if not buf or pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, NAN)
@@ -67,9 +61,7 @@ local function numSerializer(value: number, buf: buffer, pos: number, size: numb
 			else
 				2
 		
-		if not buf then
-			buf, size = buffer.create(newSize), newSize
-		elseif pos + newSize > size then
+		if not buf or pos + newSize > size then
 			buf, size = inflate(buf, pos + newSize, size)
 		end
 
@@ -88,9 +80,7 @@ local function numSerializer(value: number, buf: buffer, pos: number, size: numb
 	if value % 1 ~= 0 or value > MAX_INT or value < MIN_INT then
 
 		if MAX_FLOAT < value or value < -MAX_FLOAT then
-			if not buf then
-				buf, size = buffer.create(9), 9
-			elseif pos + 9 > size then
+			if not buf or pos + 9 > size then
 				buf, size = inflate(buf, pos + 9, size)
 			end
 			buffer.writeu8(buf, pos, DOUBLE)
@@ -101,9 +91,7 @@ local function numSerializer(value: number, buf: buffer, pos: number, size: numb
 		-- Ensures that the output WILL be the same as the input
 		-- even if it results in a slower path
 		if (vecX * value).x == value then
-			if not buf then
-				buf, size = buffer.create(5), 5
-			elseif pos + 5 > size then
+			if not buf or pos + 5 > size then
 				buf, size = inflate(buf, pos + 5, size)
 			end
 			buffer.writeu8(buf, pos, FLOAT)
@@ -111,9 +99,7 @@ local function numSerializer(value: number, buf: buffer, pos: number, size: numb
 			return buf, pos + 5, size
 		end
 		
-		if not buf then
-			buf, size = buffer.create(9), 9
-		elseif pos + 9 > size then
+		if not buf or pos + 9 > size then
 			buf, size = inflate(buf, pos + 9, size)
 		end
 		buffer.writeu8(buf, pos, DOUBLE)
@@ -130,9 +116,7 @@ local function numSerializer(value: number, buf: buffer, pos: number, size: numb
 		else
 			5
 	
-	if not buf then
-		buf, size = buffer.create(newSize), newSize
-	elseif pos + newSize > size then
+	if not buf or pos + newSize > size then
 		buf, size = inflate(buf, pos + newSize, size)
 	end
 	buffer.writeu8(buf, pos, ZERO + newSize)

--- a/src/string.luau
+++ b/src/string.luau
@@ -15,9 +15,7 @@ local WRITE = {} -- 1 to 1343
 local function strSerializer(value: string, buf: buffer, pos :number, size: number)
 
 	if value == "" then
-		if not buf then
-			buf, size = buffer.create(1), 1
-		elseif pos + 1 > size then
+		if not buf or pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, EMPTY)
@@ -31,9 +29,7 @@ local function strSerializer(value: string, buf: buffer, pos :number, size: numb
 			else
 				2
 		
-		if not buf then
-			buf, size = buffer.create(newSize), newSize
-		elseif pos + newSize > size then
+		if not buf or pos + newSize > size then
 			buf, size = inflate(buf, pos + newSize, size)
 		end
 
@@ -59,9 +55,7 @@ local function strSerializer(value: string, buf: buffer, pos :number, size: numb
 		else
 			5
 	
-	if not buf then
-		buf, size = buffer.create(len + newSize), len + newSize
-	elseif pos + len + newSize > size then
+	if not buf or pos + len + newSize > size then
 		buf, size = inflate(buf, pos + len + newSize, size)
 	end
 	buffer.writeu8(buf, pos, 8 + newSize)

--- a/src/string.luau
+++ b/src/string.luau
@@ -15,7 +15,7 @@ local WRITE = {} -- 1 to 1343
 local function strSerializer(value: string, buf: buffer, pos :number, size: number)
 
 	if value == "" then
-		if not buf or pos + 1 > size then
+		if pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, EMPTY)
@@ -29,7 +29,7 @@ local function strSerializer(value: string, buf: buffer, pos :number, size: numb
 			else
 				2
 		
-		if not buf or pos + newSize > size then
+		if pos + newSize > size then
 			buf, size = inflate(buf, pos + newSize, size)
 		end
 
@@ -55,7 +55,7 @@ local function strSerializer(value: string, buf: buffer, pos :number, size: numb
 		else
 			5
 	
-	if not buf or pos + len + newSize > size then
+	if pos + len + newSize > size then
 		buf, size = inflate(buf, pos + len + newSize, size)
 	end
 	buffer.writeu8(buf, pos, 8 + newSize)

--- a/src/userdata.luau
+++ b/src/userdata.luau
@@ -24,9 +24,7 @@ local Userdata = {
 				else
 					2
 			
-			if not buf then
-				buf, size = buffer.create(newSize), newSize
-			elseif pos + newSize > size then
+			if not buf or pos + newSize > size then
 				buf, size = inflate(buf, pos + newSize, size)
 			end
 
@@ -42,9 +40,7 @@ local Userdata = {
 		end
 
 		if Writer then
-			if not buf then
-				buf, size = buffer.create(1), 1
-			elseif pos + 1 > size then
+			if not buf or pos + 1 > size then
 				buf, size = inflate(buf, pos + 1, size)
 			end
 			buffer.writeu8(buf, pos, CUSTOM)
@@ -54,9 +50,7 @@ local Userdata = {
 				return buf, pos, size
 			end
 		end
-		if not buf then
-			buf, size = buffer.create(1), 1
-		elseif pos + 1 > size then
+		if not buf or pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, NIL)

--- a/src/userdata.luau
+++ b/src/userdata.luau
@@ -24,7 +24,7 @@ local Userdata = {
 				else
 					2
 			
-			if not buf or pos + newSize > size then
+			if pos + newSize > size then
 				buf, size = inflate(buf, pos + newSize, size)
 			end
 
@@ -40,7 +40,7 @@ local Userdata = {
 		end
 
 		if Writer then
-			if not buf or pos + 1 > size then
+			if pos + 1 > size then
 				buf, size = inflate(buf, pos + 1, size)
 			end
 			buffer.writeu8(buf, pos, CUSTOM)
@@ -50,7 +50,7 @@ local Userdata = {
 				return buf, pos, size
 			end
 		end
-		if not buf or pos + 1 > size then
+		if pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, NIL)

--- a/src/vector.luau
+++ b/src/vector.luau
@@ -73,7 +73,7 @@ local function vecSerializer(value: vector, buf: buffer, pos: number, size: numb
 
 	local builtin: number? = builtinSerialConst[value]
 	if builtin then
-		if not buf or pos + 1 > size then
+		if pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, builtin)
@@ -87,7 +87,7 @@ local function vecSerializer(value: vector, buf: buffer, pos: number, size: numb
 			else
 				2
 		
-		if not buf or pos + newSize > size then
+		if pos + newSize > size then
 			buf, size = inflate(buf, pos + newSize, size)
 		end
 
@@ -126,7 +126,7 @@ local function vecSerializer(value: vector, buf: buffer, pos: number, size: numb
 			or isXYAxis or isYZAxis
 		then
 			-- 3+ bytes
-			if not buf or pos + 3 > size then
+			if pos + 3 > size then
 				buf, size = inflate(buf, pos + 3, size)
 			end
 			buffer.writeu8(buf, pos, SCALAR_NUMBER)
@@ -184,7 +184,7 @@ local function vecSerializer(value: vector, buf: buffer, pos: number, size: numb
 	
 	-- 4+ bytes (NOT intelligent, as a const byte will be more expensive)
 	if isNumber then
-		if not buf or pos + 4 > size then
+		if pos + 4 > size then
 			buf, size = inflate(buf, pos + 4, size)
 		end
 		buffer.writeu8(buf, pos, NUMBER)
@@ -195,7 +195,7 @@ local function vecSerializer(value: vector, buf: buffer, pos: number, size: numb
 
 	local newSize = 3 * ((typeX :: number) - 143) + 1
 	-- 4, 7, 10, 13
-	if not buf or pos + newSize > size then
+	if pos + newSize > size then
 		buf, size = inflate(buf, pos + newSize, size)
 	end
 	buffer.writeu8(buf, pos, typeX :: number)

--- a/src/vector.luau
+++ b/src/vector.luau
@@ -73,9 +73,7 @@ local function vecSerializer(value: vector, buf: buffer, pos: number, size: numb
 
 	local builtin: number? = builtinSerialConst[value]
 	if builtin then
-		if not buf then
-			buf, size = buffer.create(1), 1
-		elseif pos + 1 > size then
+		if not buf or pos + 1 > size then
 			buf, size = inflate(buf, pos + 1, size)
 		end
 		buffer.writeu8(buf, pos, builtin)
@@ -89,9 +87,7 @@ local function vecSerializer(value: vector, buf: buffer, pos: number, size: numb
 			else
 				2
 		
-		if not buf then
-			buf, size = buffer.create(newSize), newSize
-		elseif pos + newSize > size then
+		if not buf or pos + newSize > size then
 			buf, size = inflate(buf, pos + newSize, size)
 		end
 
@@ -130,9 +126,7 @@ local function vecSerializer(value: vector, buf: buffer, pos: number, size: numb
 			or isXYAxis or isYZAxis
 		then
 			-- 3+ bytes
-			if not buf then
-				buf, size = buffer.create(3), 3
-			elseif pos + 3 > size then
+			if not buf or pos + 3 > size then
 				buf, size = inflate(buf, pos + 3, size)
 			end
 			buffer.writeu8(buf, pos, SCALAR_NUMBER)
@@ -190,9 +184,7 @@ local function vecSerializer(value: vector, buf: buffer, pos: number, size: numb
 	
 	-- 4+ bytes (NOT intelligent, as a const byte will be more expensive)
 	if isNumber then
-		if not buf then
-			buf, size = buffer.create(4), 4
-		elseif pos + 4 > size then
+		if not buf or pos + 4 > size then
 			buf, size = inflate(buf, pos + 4, size)
 		end
 		buffer.writeu8(buf, pos, NUMBER)
@@ -203,9 +195,7 @@ local function vecSerializer(value: vector, buf: buffer, pos: number, size: numb
 
 	local newSize = 3 * ((typeX :: number) - 143) + 1
 	-- 4, 7, 10, 13
-	if not buf then
-		buf, size = buffer.create(newSize), newSize
-	elseif pos + newSize > size then
+	if not buf or pos + newSize > size then
 		buf, size = inflate(buf, pos + newSize, size)
 	end
 	buffer.writeu8(buf, pos, typeX :: number)


### PR DESCRIPTION
Currently the internals take 5 lines per resize operation:
```luau
if not buf then
    buf, size = buffer.create(1), 1
elseif pos + 1 > size then
    buf, size = inflate(buf, pos + 1, size)
end
```

These 5 lines may not seem that complex, however they quickly harm readability.  A more readable approach would be to just say:
```luau
if pos + 1 > size then
    buf, size = inflate(buf, pos + 1, size)
end
```


### Benefits
* Improvements to readability for non-table modules
* Slight improvements to serialization performance for larger tables

### Costs
* Non-tables and small tables take a slight serialization performance hit