### PR TITLE
Patch for Pairs (#36)

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -55,7 +55,7 @@ BufferSerializer.serialize = function(value: any): buffer
 		serial = (require("@self" .. typeValue) :: any).serialize
 		serialModules[typeValue] = serial
 	end
-	return trim(serial(value, nil, 0, 0, true))
+	return trim(serial(value, nil, 0, 0))
 end
 
 --[[

--- a/src/init.luau
+++ b/src/init.luau
@@ -19,7 +19,7 @@ local BufferSerializer = {}
 
 local serialModules = {}
 local deserialModules = {}
-local pairModules = {}
+local pairModules = require("@self/link") :: { [any]: any }
 
 type Serialize = (
 	value: any,
@@ -157,20 +157,7 @@ BufferSerializer.pair = function(id: number, value: any): ()
 		`Invalid value {value} (cannot be a built-in)`
 	)
 
-	local mod: Pair = pairModules[typeV]
-	if not mod then
-		-- ...
-		mod = (
-			if typeV == "string"
-				then require("@self/string")
-				elseif typeV == "number" then require("@self/number")
-				elseif typeV == "vector" then require("@self/vector")
-				else require("@self/userdata")
-		) :: Pair
-		pairModules[typeV] = mod
-	end
-
-	mod.Write[value] = id
+	pairModules[value] = id
 end
 
 return BufferSerializer

--- a/src/init.luau
+++ b/src/init.luau
@@ -109,6 +109,9 @@ BufferSerializer.deserialize = function(value: buffer): any
 	return originalData
 end
 
+-- narrows the type emitted by `type(any): string` would like for it to error
+type TYPES = "userdata" | "number" | "string" | "vector"
+
 --[[
 	Connects a constant value to an identifier.
 	@ Only certain types are supported.
@@ -117,7 +120,7 @@ end
 	@param value the value
 ]]
 BufferSerializer.pair = function(id: number, value: any): ()
-	local typeV = type(value)
+	local typeV = type(value) :: TYPES
 	local maxId = if typeV == "string"
 		then 1343
 		elseif typeV == "number" then 1055

--- a/src/init.luau
+++ b/src/init.luau
@@ -21,6 +21,8 @@ local serialModules = {}
 local deserialModules = {}
 local pairModules = require("@self/link").values :: { [any]: any }
 
+local calcId = require("@self/link").calculateId
+
 type Serialize = (
 	value: any,
 	buf: buffer?,
@@ -157,35 +159,7 @@ BufferSerializer.pair = function(id: number, value: any): ()
 		`Invalid value {value} (cannot be a built-in)`
 	)
 
-	local count = if typeV == "string"
-		then 64
-		elseif typeV == "number" then 32
-		elseif typeV == "vector" then 32
-		else 16
-
-	local start = if typeV == "string"
-		then 18
-		elseif typeV == "number" then 99
-		elseif typeV == "vector" then 157
-		else 203
-
-	local duostart = if typeV == "string"
-		then 83
-		elseif typeV == "number" then 132
-		elseif typeV == "vector" then 190
-		else 220
-
-	local calcId
-	local newSize = if id <= count then 1 else 2
-
-	if newSize == 1 then
-		calcId = id + start
-	else
-		local constVal = id - count
-		calcId = constVal * 256 + (duostart + constVal // 256)
-	end
-
-	pairModules[value] = calcId
+	pairModules[value] = calcId(id, typeV)
 end
 
 return BufferSerializer

--- a/src/init.luau
+++ b/src/init.luau
@@ -52,7 +52,7 @@ BufferSerializer.serialize = function(value: any): buffer
 
 	local serial: Serialize = serialModules[typeValue]
 	if not serial then
-		serial = (require("@self" .. typeValue) :: any).serialize
+		serial = (require("@self/" .. typeValue) :: any).serialize
 		serialModules[typeValue] = serial
 	end
 	return trim(serial(value, nil, 0, 0))

--- a/src/init.luau
+++ b/src/init.luau
@@ -19,7 +19,7 @@ local BufferSerializer = {}
 
 local serialModules = {}
 local deserialModules = {}
-local pairModules = require("@self/link") :: { [any]: any }
+local pairModules = require("@self/link").values :: { [any]: any }
 
 type Serialize = (
 	value: any,
@@ -157,7 +157,35 @@ BufferSerializer.pair = function(id: number, value: any): ()
 		`Invalid value {value} (cannot be a built-in)`
 	)
 
-	pairModules[value] = id
+	local count = if typeV == "string"
+		then 64
+		elseif typeV == "number" then 32
+		elseif typeV == "vector" then 32
+		else 16
+
+	local start = if typeV == "string"
+		then 18
+		elseif typeV == "number" then 99
+		elseif typeV == "vector" then 157
+		else 203
+
+	local duostart = if typeV == "string"
+		then 83
+		elseif typeV == "number" then 132
+		elseif typeV == "vector" then 190
+		else 220
+
+	local calcId
+	local newSize = if id <= count then 1 else 2
+
+	if newSize == 1 then
+		calcId = id + start
+	else
+		local constVal = id - count
+		calcId = constVal * 256 + (duostart + constVal // 256)
+	end
+
+	pairModules[value] = calcId
 end
 
 return BufferSerializer

--- a/src/init.luau
+++ b/src/init.luau
@@ -30,7 +30,6 @@ type Serialize = (
 type Deserialize = (value: buffer, pos: number) -> (any, number)
 type Pair = {
 	[any]: any,
-	Read: { [any]: any },
 	Write: { [any]: any },
 }
 
@@ -171,15 +170,6 @@ BufferSerializer.pair = function(id: number, value: any): ()
 		pairModules[typeV] = mod
 	end
 
-	-- Same value, different id
-	if mod.Write[value] ~= nil then
-		mod.Read[mod.Write[value]] = nil
-	end
-	-- Same id, different value
-	if mod.Read[id] ~= nil then
-		mod.Write[mod.Read[id]] = nil
-	end
-	mod.Read[id] = value
 	mod.Write[value] = id
 end
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -62,7 +62,7 @@ BufferSerializer.serialize = function(value: any): buffer
 		serial = temp.serialize :: Serialize
 		serialModules[typeValue] = serial
 	end
-	return trim(serial(value, nil, 0, 0))
+	return trim(serial(value, nil, 0, 0, true))
 end
 
 --[[

--- a/src/init.luau
+++ b/src/init.luau
@@ -16,12 +16,14 @@ local function trim(data: buffer, pos: number, size: number)
 end
 
 local BufferSerializer = {}
+local link = require("@self/link")
 
 local serialModules = {}
 local deserialModules = {}
-local pairModules = require("@self/link").values :: { [any]: any }
+local pairModules = link.values :: { [any]: any }
 
-local calcId = require("@self/link").calculateId
+local calcId = link.calculateId
+local linkType = link.type
 
 type Serialize = (
 	value: any,
@@ -50,17 +52,7 @@ BufferSerializer.serialize = function(value: any): buffer
 
 	local serial: Serialize = serialModules[typeValue]
 	if not serial then
-		local temp = if typeValue == "nil"
-			then require("@self/nil")
-			elseif typeValue == "boolean" then require("@self/boolean")
-			elseif typeValue == "buffer" then require("@self/buffer")
-			elseif typeValue == "string" then require("@self/string")
-			elseif typeValue == "number" then require("@self/number")
-			elseif typeValue == "vector" then require("@self/vector")
-			elseif typeValue == "table" then require("@self/table")
-			else require("@self/userdata")
-
-		serial = temp.serialize :: Serialize
+		serial = (require("@self" .. typeValue) :: any).serialize
 		serialModules[typeValue] = serial
 	end
 	return trim(serial(value, nil, 0, 0, true))
@@ -79,29 +71,11 @@ BufferSerializer.deserialize = function(value: buffer): any
 		return nil
 	end
 
-	pointer = if pointer <= 2
-		then 1 -- boolean
-		elseif pointer <= 8 then 2 -- buffer
-		elseif pointer <= 87 then 3 -- string
-		elseif pointer <= 135 then 4 -- number
-		elseif pointer <= 193 then 5 -- vector
-		elseif pointer <= 201 then 6 -- table
-		elseif pointer <= 223 then 7 -- userdata
-		else 0 -- add more if statements if needed for future
+	pointer = linkType(pointer)
 
 	local deserial: Deserialize = deserialModules[pointer]
 	if not deserial then
-		local temp = if pointer == 0
-			then require("@self/nil")
-			elseif pointer == 1 then require("@self/boolean")
-			elseif pointer == 2 then require("@self/buffer")
-			elseif pointer == 3 then require("@self/string")
-			elseif pointer == 4 then require("@self/number")
-			elseif pointer == 5 then require("@self/vector")
-			elseif pointer == 6 then require("@self/table")
-			else require("@self/userdata")
-
-		deserial = temp.deserialize
+		deserial = (require("@self/" .. pointer) :: any).deserialize
 		deserialModules[pointer] = deserial
 	end
 

--- a/src/link.luau
+++ b/src/link.luau
@@ -5,6 +5,9 @@ local inflate = require("./inflate")
 
 local link = {}
 
+type TYPES = "userdata" | "number" | "string" | "vector"
+type SERIALIZABLE_TYPES = TYPES | "boolean" | "buffer" | "nil" | "table"
+
 -- possibly used in table?
 local STRING_COUNT = 64
 local NUMBER_COUNT = 32
@@ -28,35 +31,48 @@ local USER_DUOSTART = 220
 
 link.values = {}
 
+--[[
+	Appends the id to the buffer at the given position, returning the inputs.
+
+	@param id the internal representation of the id associated with a value
+	@param buf the buffer to append the id to
+	@param pos the position in the buffer to append the id to
+	@param size the size of the buffer
+]]
 @native
-function link.serialize(value: number, buf: buffer, pos: number, size: number)
+function link.serialize(id: number, buf: buffer, pos: number, size: number)
 	if pos + 2 > size then
 		buf, size = inflate(buf, pos + 2, size)
 	end
-	buffer.writeu16(buf, pos, value)
-	return buf, pos + (value > 255 and 2 or 1), size, value :: any
+	buffer.writeu16(buf, pos, id)
+	return buf, pos + (id > 255 and 2 or 1), size, id :: any
 end
 
-type TYPES = "userdata" | "number" | "string" | "vector"
+--[[
+	Returns the internal representation of the id based on the provided type.
+	That is, the value to store when serializing the value in tables.
 
+	@param id the id to pair to a value
+	@param type the type of the paired value
+]]
 @native
-function link.calculateId(id: number, typeV: TYPES)
-	local count = if typeV == "string"
+function link.calculateId(id: number, type: TYPES): number
+	local count = if type == "string"
 		then STRING_COUNT
-		elseif typeV == "number" then NUMBER_COUNT
-		elseif typeV == "vector" then VECTOR_COUNT
+		elseif type == "number" then NUMBER_COUNT
+		elseif type == "vector" then VECTOR_COUNT
 		else USER_COUNT
 
-	local start = if typeV == "string"
+	local start = if type == "string"
 		then STRING_START
-		elseif typeV == "number" then NUMBER_START
-		elseif typeV == "vector" then VECTOR_START
+		elseif type == "number" then NUMBER_START
+		elseif type == "vector" then VECTOR_START
 		else USER_START
 
-	local duostart = if typeV == "string"
+	local duostart = if type == "string"
 		then STRING_DUOSTART
-		elseif typeV == "number" then NUMBER_DUOSTART
-		elseif typeV == "vector" then VECTOR_DUOSTART
+		elseif type == "number" then NUMBER_DUOSTART
+		elseif type == "vector" then VECTOR_DUOSTART
 		else USER_DUOSTART
 
 	local calcId
@@ -70,6 +86,52 @@ function link.calculateId(id: number, typeV: TYPES)
 	end
 
 	return calcId
+end
+
+--[[
+	Returns the type of reference id
+
+	@param refId the byte containing the type and location of the id paired to a value
+]]
+@native
+function link.type(refId: number): SERIALIZABLE_TYPES
+	return if refId <= 2
+		then "boolean"
+		elseif refId <= 8 then "buffer"
+		elseif refId <= 87 then "string"
+		elseif refId <= 135 then "number"
+		elseif refId <= 193 then "vector"
+		elseif refId <= 201 then "table"
+		elseif refId <= 223 then "userdata"
+		else "nil" -- add more if statements if needed for future
+end
+
+--[[
+	Returns whether the byte is linked
+
+	@param byte the byte read
+	@param type value type
+]]
+@native
+function link.islink(byte: number, type: SERIALIZABLE_TYPES): boolean
+	return type == "string" and byte > STRING_START
+		or type == "number" and byte > NUMBER_START
+		or type == "vector" and byte > VECTOR_START
+		or type == "userdata" and byte > USER_START
+end
+
+--[[
+	Returns whether the value associated with the link is 2 bytes
+
+	@param byte the byte read
+	@param type the value type
+]]
+@native
+function link.isduo(byte: number, type: SERIALIZABLE_TYPES): boolean
+	return type == "string" and byte >= STRING_DUOSTART
+		or type == "number" and byte >= NUMBER_DUOSTART
+		or type == "vector" and byte >= VECTOR_DUOSTART
+		or type == "userdata" and byte >= USER_DUOSTART
 end
 
 return table.freeze(link)

--- a/src/link.luau
+++ b/src/link.luau
@@ -1,6 +1,25 @@
+--!optimize 2
+--!strict
+
 local inflate = require("./inflate")
 
 local link = {}
+
+-- possibly used in table?
+local STRING_COUNT = 64
+local NUMBER_COUNT = 32
+local VECTOR_COUNT = 32
+local USER_COUNT = 16
+
+local STRING_START = 18
+local NUMBER_START = 99
+local VECTOR_START = 157
+local USER_START = 203
+
+local STRING_DUOSTART = 83
+local NUMBER_DUOSTART = 132
+local VECTOR_DUOSTART = 190
+local USER_DUOSTART = 220
 
 -- string: 1 to 1343
 -- number: 1 to 1055
@@ -16,6 +35,41 @@ function link.serialize(value: number, buf: buffer, pos: number, size: number)
 	end
 	buffer.writeu16(buf, pos, value)
 	return buf, pos + (value > 255 and 2 or 1), size, value :: any
+end
+
+type TYPES = "userdata" | "number" | "string" | "vector"
+
+@native
+function link.calculateId(id: number, typeV: TYPES)
+	local count = if typeV == "string"
+		then STRING_COUNT
+		elseif typeV == "number" then NUMBER_COUNT
+		elseif typeV == "vector" then VECTOR_COUNT
+		else USER_COUNT
+
+	local start = if typeV == "string"
+		then STRING_START
+		elseif typeV == "number" then NUMBER_START
+		elseif typeV == "vector" then VECTOR_START
+		else USER_START
+
+	local duostart = if typeV == "string"
+		then STRING_DUOSTART
+		elseif typeV == "number" then NUMBER_DUOSTART
+		elseif typeV == "vector" then VECTOR_DUOSTART
+		else USER_DUOSTART
+
+	local calcId
+	local newSize = if id <= count then 1 else 2
+
+	if newSize == 1 then
+		calcId = id + start
+	else
+		local constVal = id - count
+		calcId = constVal * 256 + (duostart + constVal // 256)
+	end
+
+	return calcId
 end
 
 return link

--- a/src/link.luau
+++ b/src/link.luau
@@ -72,4 +72,4 @@ function link.calculateId(id: number, typeV: TYPES)
 	return calcId
 end
 
-return link
+return table.freeze(link)

--- a/src/link.luau
+++ b/src/link.luau
@@ -1,8 +1,21 @@
+local inflate = require("./inflate")
+
 local link = {}
 
 -- string: 1 to 1343
 -- number: 1 to 1055
 -- vector: 1 to 1055
 -- userdata: 1 to 1039
+
+link.values = {}
+
+@native
+function link.serialize(value: number, buf: buffer, pos: number, size: number)
+	if pos + 2 > size then
+		buf, size = inflate(buf, pos + 2, size)
+	end
+	buffer.writeu16(buf, pos, value)
+	return buf, pos + (value > 255 and 2 or 1), size, value :: any
+end
 
 return link

--- a/src/link.luau
+++ b/src/link.luau
@@ -1,0 +1,8 @@
+local link = {}
+
+-- string: 1 to 1343
+-- number: 1 to 1055
+-- vector: 1 to 1055
+-- userdata: 1 to 1039
+
+return link

--- a/src/number.luau
+++ b/src/number.luau
@@ -36,7 +36,8 @@ local function numSerializer(
 	value: number,
 	buf: buffer,
 	pos: number,
-	size: number
+	size: number,
+	skipPairs: boolean?
 )
 	if value == 0 or value == 1 or value ~= value then
 		if pos + 1 > size then
@@ -52,23 +53,25 @@ local function numSerializer(
 		return buf, pos + 1, size
 	end
 
-	local cachedConstant: number? = WRITE[value]
-	if cachedConstant then
-		local newSize = if cachedConstant <= 32 then 1 else 2
+	if not skipPairs then
+		local cachedConstant: number? = WRITE[value]
+		if cachedConstant then
+			local newSize = if cachedConstant <= 32 then 1 else 2
 
-		if pos + newSize > size then
-			buf, size = inflate(buf, pos + newSize, size)
+			if pos + newSize > size then
+				buf, size = inflate(buf, pos + newSize, size)
+			end
+
+			if newSize == 1 then
+				buffer.writeu8(buf, pos, cachedConstant + 99)
+			else
+				local constVal = cachedConstant - 32
+				buffer.writeu8(buf, pos, 132 + (constVal // 256))
+				buffer.writeu8(buf, pos + 1, constVal)
+			end
+
+			return buf, pos + newSize, size
 		end
-
-		if newSize == 1 then
-			buffer.writeu8(buf, pos, cachedConstant + 99)
-		else
-			local constVal = cachedConstant - 32
-			buffer.writeu8(buf, pos, 132 + (constVal // 256))
-			buffer.writeu8(buf, pos + 1, constVal)
-		end
-
-		return buf, pos + newSize, size
 	end
 
 	-- Floating points

--- a/src/number.luau
+++ b/src/number.luau
@@ -28,7 +28,6 @@ local MAX_FLOAT = 2 ^ 127
 
 local vecX = vector.create(1, 0)
 
-local READ = {}
 local WRITE = {} -- 1 to 1055
 
 @native
@@ -161,23 +160,12 @@ local function numDeserializer(buf: buffer, pos: number): (number?, number)
 end
 
 local Number = {
-	Read = READ,
 	Write = WRITE,
 
 	serialize = numSerializer,
 	deserialize = numDeserializer,
 }
 
---[[
-	Clears and replaces the read table
-	
-	@ Mainly used to reduce memory usage
-]]
-function Number.resetRead()
-	table.clear(READ)
-	READ = {}
-	Number.Read = READ
-end
 --[[
 	Clears and replaces the write table
 	

--- a/src/number.luau
+++ b/src/number.luau
@@ -139,17 +139,6 @@ local function numDeserializer(buf: buffer, pos: number): (number?, number)
 		return 0 / 0, pos + 1
 	end
 
-	if id > 99 then
-		local cachedId = if id > 131
-			then (id - 132) * 256 + 32 + buffer.readu8(buf, pos + 1)
-			else id - 99
-
-		local cachedConstant: number? = READ[cachedId]
-		if cachedConstant then
-			return cachedConstant, pos + (if cachedId > 32 then 2 else 1)
-		end
-	end
-
 	if id == BYTE then
 		return buffer.readi8(buf, pos + 1), pos + 2
 	elseif id == CHAR then

--- a/src/number.luau
+++ b/src/number.luau
@@ -28,15 +28,12 @@ local MAX_FLOAT = 2 ^ 127
 
 local vecX = vector.create(1, 0)
 
-local WRITE = {} -- 1 to 1055
-
 @native
 local function numSerializer(
 	value: number,
 	buf: buffer,
 	pos: number,
-	size: number,
-	skipPairs: boolean?
+	size: number
 )
 	if value == 0 or value == 1 or value ~= value then
 		if pos + 1 > size then
@@ -50,27 +47,6 @@ local function numSerializer(
 		)
 
 		return buf, pos + 1, size
-	end
-
-	if not skipPairs then
-		local cachedConstant: number? = WRITE[value]
-		if cachedConstant then
-			local newSize = if cachedConstant <= 32 then 1 else 2
-
-			if pos + newSize > size then
-				buf, size = inflate(buf, pos + newSize, size)
-			end
-
-			if newSize == 1 then
-				buffer.writeu8(buf, pos, cachedConstant + 99)
-			else
-				local constVal = cachedConstant - 32
-				buffer.writeu8(buf, pos, 132 + (constVal // 256))
-				buffer.writeu8(buf, pos + 1, constVal)
-			end
-
-			return buf, pos + newSize, size
-		end
 	end
 
 	-- Floating points
@@ -160,21 +136,8 @@ local function numDeserializer(buf: buffer, pos: number): (number?, number)
 end
 
 local Number = {
-	Write = WRITE,
-
 	serialize = numSerializer,
 	deserialize = numDeserializer,
 }
-
---[[
-	Clears and replaces the write table
-	
-	@ Mainly used to reduce memory usage
-]]
-function Number.resetWrite()
-	table.clear(WRITE)
-	WRITE = {}
-	Number.Write = WRITE
-end
 
 return Number

--- a/src/string.luau
+++ b/src/string.luau
@@ -16,7 +16,8 @@ local function strSerializer(
 	value: string,
 	buf: buffer,
 	pos: number,
-	size: number
+	size: number,
+	skipPairs: boolean?
 )
 	if value == "" then
 		if pos + 1 > size then
@@ -26,23 +27,25 @@ local function strSerializer(
 		return buf, pos + 1, size
 	end
 
-	local cachedConstant: number? = WRITE[value]
-	if cachedConstant then
-		local newSize = if cachedConstant <= 64 then 1 else 2
+	if not skipPairs then
+		local cachedConstant: number? = WRITE[value]
+		if cachedConstant then
+			local newSize = if cachedConstant <= 64 then 1 else 2
 
-		if pos + newSize > size then
-			buf, size = inflate(buf, pos + newSize, size)
+			if pos + newSize > size then
+				buf, size = inflate(buf, pos + newSize, size)
+			end
+
+			if newSize == 1 then
+				buffer.writeu8(buf, pos, cachedConstant + 18)
+			else
+				local constVal = cachedConstant - 64
+				buffer.writeu8(buf, pos, 83 + (constVal // 256))
+				buffer.writeu8(buf, pos + 1, constVal)
+			end
+
+			return buf, pos + newSize, size
 		end
-
-		if newSize == 1 then
-			buffer.writeu8(buf, pos, cachedConstant + 18)
-		else
-			local constVal = cachedConstant - 64
-			buffer.writeu8(buf, pos, 83 + (constVal // 256))
-			buffer.writeu8(buf, pos + 1, constVal)
-		end
-
-		return buf, pos + newSize, size
 	end
 
 	local len = #value

--- a/src/string.luau
+++ b/src/string.luau
@@ -8,15 +8,12 @@ local CHAR = 11
 local THREE_BYTE = 12
 local INT = 13
 
-local WRITE = {} -- 1 to 1343
-
 @native
 local function strSerializer(
 	value: string,
 	buf: buffer,
 	pos: number,
-	size: number,
-	skipPairs: boolean?
+	size: number
 )
 	if value == "" then
 		if pos + 1 > size then
@@ -24,27 +21,6 @@ local function strSerializer(
 		end
 		buffer.writeu8(buf, pos, EMPTY)
 		return buf, pos + 1, size
-	end
-
-	if not skipPairs then
-		local cachedConstant: number? = WRITE[value]
-		if cachedConstant then
-			local newSize = if cachedConstant <= 64 then 1 else 2
-
-			if pos + newSize > size then
-				buf, size = inflate(buf, pos + newSize, size)
-			end
-
-			if newSize == 1 then
-				buffer.writeu8(buf, pos, cachedConstant + 18)
-			else
-				local constVal = cachedConstant - 64
-				buffer.writeu8(buf, pos, 83 + (constVal // 256))
-				buffer.writeu8(buf, pos + 1, constVal)
-			end
-
-			return buf, pos + newSize, size
-		end
 	end
 
 	local len = #value
@@ -103,21 +79,8 @@ local function strDeserializer(buf: buffer, pos: number): (string?, number)
 end
 
 local String = {
-	Write = WRITE,
-
 	serialize = strSerializer,
 	deserialize = strDeserializer,
 }
-
---[[
-	Clears and replaces the write table
-	
-	@ Mainly used to reduce memory usage
-]]
-function String.resetWrite()
-	table.clear(WRITE)
-	WRITE = {}
-	String.Write = WRITE
-end
 
 return String

--- a/src/string.luau
+++ b/src/string.luau
@@ -8,7 +8,6 @@ local CHAR = 11
 local THREE_BYTE = 12
 local INT = 13
 
-local READ = {}
 local WRITE = {} -- 1 to 1343
 
 @native
@@ -104,23 +103,12 @@ local function strDeserializer(buf: buffer, pos: number): (string?, number)
 end
 
 local String = {
-	Read = READ,
 	Write = WRITE,
 
 	serialize = strSerializer,
 	deserialize = strDeserializer,
 }
 
---[[
-	Clears and replaces the read table
-
-	@ Mainly used to reduce memory usage
-]]
-function String.resetRead()
-	table.clear(READ)
-	READ = {}
-	String.Read = READ
-end
 --[[
 	Clears and replaces the write table
 	

--- a/src/string.luau
+++ b/src/string.luau
@@ -83,17 +83,6 @@ local function strDeserializer(buf: buffer, pos: number): (string?, number)
 		return "", pos + 1
 	end
 
-	if id > 18 then
-		local cachedId = if id > 82
-			then (id - 83) * 256 + 64 + buffer.readu8(buf, pos + 1)
-			else id - 18
-
-		local cachedConstant: string? = READ[cachedId]
-		if cachedConstant then
-			return cachedConstant, pos + (if cachedId > 64 then 2 else 1)
-		end
-	end
-
 	local lenSize = id - EMPTY
 
 	local len: number

--- a/src/table.luau
+++ b/src/table.luau
@@ -26,30 +26,30 @@ local serialSwitch: Switch<string, Serialize> = {
 	boolean = require("./boolean").serialize,
 	buffer = require("./buffer").serialize,
 	string = @native function(data: any, buf: buffer, pos: number, size: number)
-		local linkValue = link[data]
-		if linkValue then
-			return linkSer(linkValue, buf, pos, size)
+		local linkId = link[data]
+		if linkId then
+			return linkSer(linkId, buf, pos, size)
 		end
 		return strSer(data, buf, pos, size)
 	end,
 	number = @native function(data: any, buf: buffer, pos: number, size: number)
-		local linkValue = link[data]
-		if linkValue then
-			return linkSer(linkValue, buf, pos, size)
+		local linkId = link[data]
+		if linkId then
+			return linkSer(linkId, buf, pos, size)
 		end
 		return numSer(data, buf, pos, size)
 	end,
 	vector = @native function(data: any, buf: buffer, pos: number, size: number)
-		local linkValue = link[data]
-		if linkValue then
-			return linkSer(linkValue, buf, pos, size)
+		local linkId = link[data]
+		if linkId then
+			return linkSer(linkId, buf, pos, size)
 		end
 		return vecSer(data, buf, pos, size)
 	end,
 	userdata = @native function(data: any, buf: buffer, pos: number, size: number)
-		local linkValue = link[data]
-		if linkValue then
-			return linkSer(linkValue, buf, pos, size)
+		local linkId = link[data]
+		if linkId then
+			return linkSer(linkId, buf, pos, size)
 		end
 		return userSer(data, buf, pos, size)
 	end,
@@ -167,12 +167,12 @@ function tabSerializer(
 			return
 		end
 
-		local oldPos, triggered = pos, nil
-		buf, pos, size, triggered = serialSwitch[typeName](data, buf, pos, size)
+		local oldPos, pairedId = pos, nil
+		buf, pos, size, pairedId = serialSwitch[typeName](data, buf, pos, size)
 
 		if pos - oldPos == 1 then
-			if triggered then
-				constants[data] = triggered
+			if pairedId then
+				constants[data] = pairedId
 				buf, pos, size = unlinkedSwitch[typeName](data, buf, pos, size)
 				return
 			end
@@ -180,8 +180,8 @@ function tabSerializer(
 			local serValue = buffer.readu8(buf, oldPos)
 			constants[data] = serValue
 		elseif pos - oldPos == 2 then
-			if triggered then
-				constants[data] = triggered
+			if pairedId then
+				constants[data] = pairedId
 				buf, pos, size = unlinkedSwitch[typeName](data, buf, pos, size)
 				return
 			end

--- a/src/table.luau
+++ b/src/table.luau
@@ -1,6 +1,7 @@
 --!optimize 2
 --!strict
 local inflate = require("./inflate")
+local link = require("./link") :: { [any]: any }
 
 type Serialize = (
 	data: any,
@@ -15,13 +16,75 @@ type Switch<VAR, F> = {
 	[VAR]: F,
 }
 
+local strSer = require("./string").serialize
+local numSer = require("./number").serialize
+local vecSer = require("./vector").serialize
+local userSer = require("./userdata").serialize
+
+@native
+local function linkSer(
+	buf: buffer,
+	pos: number,
+	size: number,
+	cachedConstant: number,
+	count: number,
+	start: number,
+	duostart: number
+)
+	local newSize = if cachedConstant <= count then 1 else 2
+
+	if pos + newSize > size then
+		buf, size = inflate(buf, pos + newSize, size)
+	end
+
+	if newSize == 1 then
+		buffer.writeu8(buf, pos, cachedConstant + start)
+	else
+		local constVal = cachedConstant - count
+		buffer.writeu8(buf, pos, duostart + (constVal // 256))
+		buffer.writeu8(buf, pos + 1, constVal)
+	end
+
+	return buf, pos + newSize, size, true :: any
+end
+
 local serialSwitch: Switch<string, Serialize> = {
 	boolean = require("./boolean").serialize,
 	buffer = require("./buffer").serialize,
-	string = require("./string").serialize,
-	number = require("./number").serialize,
-	vector = require("./vector").serialize,
-	userdata = require("./userdata").serialize,
+	string = @native function(data: any, buf: buffer, pos: number, size: number)
+		local linkValue = link[data]
+		if linkValue then
+			return linkSer(buf, pos, size, linkValue, 64, 18, 83)
+		end
+		return strSer(data, buf, pos, size)
+	end,
+	number = @native function(data: any, buf: buffer, pos: number, size: number)
+		local linkValue = link[data]
+		if linkValue then
+			return linkSer(buf, pos, size, linkValue, 32, 99, 132)
+		end
+		return numSer(data, buf, pos, size)
+	end,
+	vector = @native function(data: any, buf: buffer, pos: number, size: number)
+		local linkValue = link[data]
+		if linkValue then
+			return linkSer(buf, pos, size, linkValue, 32, 157, 190)
+		end
+		return vecSer(data, buf, pos, size)
+	end,
+	userdata = @native function(data: any, buf: buffer, pos: number, size: number)
+		local linkValue = link[data]
+		if linkValue then
+			return linkSer(buf, pos, size, linkValue, 16, 203, 220)
+		end
+		return userSer(data, buf, pos, size)
+	end,
+}
+local unlinkedSwitch: Switch<string, Serialize> = {
+	string = strSer,
+	number = numSer,
+	vector = vecSer,
+	userdata = userSer,
 }
 
 local deserialSwitch: Switch<number, Deserialize> = {
@@ -130,39 +193,25 @@ function tabSerializer(
 			return
 		end
 
-		local oldPos = pos
-		buf, pos, size = serialSwitch[typeName](data, buf, pos, size)
+		local oldPos, triggered = pos, nil
+		buf, pos, size, triggered = serialSwitch[typeName](data, buf, pos, size)
 
 		if pos - oldPos == 1 then
 			local serValue = buffer.readu8(buf, oldPos)
 			constants[data] = serValue
-			if
-				typeName == "string" and serValue > 13
-				or typeName == "number" and serValue > 96
-				or typeName == "vector" and serValue > 149
-				or typeName == "userdata" and serValue > 203
-			then
-				-- Bypasses the id, only happens once!
-				buf, pos, size =
-					serialSwitch[typeName](data, buf, pos, size, true)
+			if not triggered then
+				return
 			end
+
+			buf, pos, size = unlinkedSwitch[typeName](data, buf, pos, size)
 		elseif pos - oldPos == 2 then
 			local serValue = buffer.readu16(buf, oldPos)
 			constants[data] = serValue
-
-			-- will change for reformatstringpack
-			-- string can never be 2 bytes currently except for pairs
-			if
-				typeName == "string"
-				or typeName == "number" and bit32.extract(serValue, 0, 8) > 90
-				or typeName == "vector"
-				or typeName == "userdata"
-					and bit32.extract(serValue, 0, 8) > 202
-			then
-				-- Bypasses the id, only happens once!
-				buf, pos, size =
-					serialSwitch[typeName](data, buf, pos, size, true)
+			if not triggered then
+				return
 			end
+
+			buf, pos, size = unlinkedSwitch[typeName](data, buf, pos, size)
 		elseif data == data then
 			existingCache(data)
 		end

--- a/src/table.luau
+++ b/src/table.luau
@@ -1,8 +1,12 @@
 --!optimize 2
 --!strict
 local inflate = require("./inflate")
-local link = require("./link").values :: { [any]: any }
-local linkSer = require("./link").serialize
+local link = require("./link")
+local linkValues = link.values :: { [any]: any }
+local linkSer = link.serialize
+local linkType = link.type
+local isLink = link.islink
+local isDuo = link.isduo
 
 type Serialize = (
 	data: any,
@@ -26,28 +30,28 @@ local serialSwitch: Switch<string, Serialize> = {
 	boolean = require("./boolean").serialize,
 	buffer = require("./buffer").serialize,
 	string = @native function(data: any, buf: buffer, pos: number, size: number)
-		local linkId = link[data]
+		local linkId = linkValues[data]
 		if linkId then
 			return linkSer(linkId, buf, pos, size)
 		end
 		return strSer(data, buf, pos, size)
 	end,
 	number = @native function(data: any, buf: buffer, pos: number, size: number)
-		local linkId = link[data]
+		local linkId = linkValues[data]
 		if linkId then
 			return linkSer(linkId, buf, pos, size)
 		end
 		return numSer(data, buf, pos, size)
 	end,
 	vector = @native function(data: any, buf: buffer, pos: number, size: number)
-		local linkId = link[data]
+		local linkId = linkValues[data]
 		if linkId then
 			return linkSer(linkId, buf, pos, size)
 		end
 		return vecSer(data, buf, pos, size)
 	end,
 	userdata = @native function(data: any, buf: buffer, pos: number, size: number)
-		local linkId = link[data]
+		local linkId = linkValues[data]
 		if linkId then
 			return linkSer(linkId, buf, pos, size)
 		end
@@ -61,13 +65,13 @@ local unlinkedSwitch: Switch<string, Serialize> = {
 	userdata = userSer,
 }
 
-local deserialSwitch: Switch<number, Deserialize> = {
-	require("./boolean").deserialize,
-	require("./buffer").deserialize,
-	require("./string").deserialize,
-	require("./number").deserialize,
-	require("./vector").deserialize,
-	require("./userdata").deserialize,
+local deserialSwitch: Switch<string, Deserialize> = {
+	boolean = require("./boolean").deserialize,
+	buffer = require("./buffer").deserialize,
+	string = require("./string").deserialize,
+	number = require("./number").deserialize,
+	vector = require("./vector").deserialize,
+	userdata = require("./userdata").deserialize,
 }
 
 local EMPTY = 194
@@ -369,26 +373,10 @@ function tabDeserializer(buf: buffer, pos: number): ({ [any]: any }?, number)
 
 		local value: any = nil
 		local oldPos = pos
-		local case = if valId <= 2
-			then 1 -- boolean
-			elseif valId <= 8 then 2 -- buffer
-			elseif valId <= 87 then 3 -- string
-			elseif valId <= 135 then 4 -- number
-			elseif valId <= 193 then 5 -- vector
-			elseif valId <= 201 then 0 -- table (none currently that can get here)
-			elseif valId <= 223 then 6 -- userdata
-			else 0 -- for future
+		local case = linkType(valId)
 
-		if
-			case == 3 and valId > 13
-			or case == 4 and valId > 96
-			or case == 5 and valId > 149
-			or case == 6 and valId > 203
-		then
-			local isTwo = case == 3 and valId > 82
-				or case == 4 and valId > 131
-				or case == 5 and valId > 189
-				or valId > 219
+		if isLink(valId, case) then
+			local isTwo = isDuo(valId, case)
 
 			local pairedValue = paired[valId]
 			if pairedValue then

--- a/src/table.luau
+++ b/src/table.luau
@@ -104,7 +104,7 @@ function tabSerializer(
 	local roundRobinLength = 0
 	local roundRobinIndex = 61440
 
-	local constants = {}
+	local constants: { [any]: number } = {}
 
 	local serialTable: (data: { [any]: any }) -> ()
 
@@ -223,16 +223,7 @@ function tabSerializer(
 				end
 				cached = constants[element]
 				if cached then
-					local newSize = cached > 255 and 2 or 1
-					if pos + newSize > size then
-						buf, size = inflate(buf, pos + newSize, size)
-					end
-					if newSize == 1 then
-						buffer.writeu8(buf, pos, cached)
-					else
-						buffer.writeu16(buf, pos, cached)
-					end
-					pos += newSize
+					buf, pos, size = linkSer(cached, buf, pos, size)
 					continue
 				end
 
@@ -283,16 +274,7 @@ function tabSerializer(
 
 			local constCached = constants[key]
 			if constCached and not cached then
-				local newSize = constCached > 255 and 2 or 1
-				if pos + newSize > size then
-					buf, size = inflate(buf, pos + newSize, size)
-				end
-				if newSize == 1 then
-					buffer.writeu8(buf, pos, constCached)
-				else
-					buffer.writeu16(buf, pos, constCached)
-				end
-				pos += newSize
+				buf, pos, size = linkSer(constCached, buf, pos, size)
 			elseif not cached then
 				-- store key
 				serialCache(key, typeKey)
@@ -311,16 +293,7 @@ function tabSerializer(
 			end
 			cached = constants[element]
 			if cached then
-				local newSize = cached > 255 and 2 or 1
-				if pos + newSize > size then
-					buf, size = inflate(buf, pos + newSize, size)
-				end
-				if newSize == 1 then
-					buffer.writeu8(buf, pos, cached)
-				else
-					buffer.writeu16(buf, pos, cached)
-				end
-				pos += newSize
+				buf, pos, size = linkSer(cached, buf, pos, size)
 				continue
 			end
 

--- a/src/table.luau
+++ b/src/table.luau
@@ -1,7 +1,8 @@
 --!optimize 2
 --!strict
 local inflate = require("./inflate")
-local link = require("./link") :: { [any]: any }
+local link = require("./link").values :: { [any]: any }
+local linkSer = require("./link").serialize
 
 type Serialize = (
 	data: any,
@@ -21,61 +22,34 @@ local numSer = require("./number").serialize
 local vecSer = require("./vector").serialize
 local userSer = require("./userdata").serialize
 
-@native
-local function linkSer(
-	buf: buffer,
-	pos: number,
-	size: number,
-	cachedConstant: number,
-	count: number,
-	start: number,
-	duostart: number
-)
-	local newSize = if cachedConstant <= count then 1 else 2
-
-	if pos + newSize > size then
-		buf, size = inflate(buf, pos + newSize, size)
-	end
-
-	if newSize == 1 then
-		buffer.writeu8(buf, pos, cachedConstant + start)
-	else
-		local constVal = cachedConstant - count
-		buffer.writeu8(buf, pos, duostart + (constVal // 256))
-		buffer.writeu8(buf, pos + 1, constVal)
-	end
-
-	return buf, pos + newSize, size, true :: any
-end
-
 local serialSwitch: Switch<string, Serialize> = {
 	boolean = require("./boolean").serialize,
 	buffer = require("./buffer").serialize,
 	string = @native function(data: any, buf: buffer, pos: number, size: number)
 		local linkValue = link[data]
 		if linkValue then
-			return linkSer(buf, pos, size, linkValue, 64, 18, 83)
+			return linkSer(linkValue, buf, pos, size)
 		end
 		return strSer(data, buf, pos, size)
 	end,
 	number = @native function(data: any, buf: buffer, pos: number, size: number)
 		local linkValue = link[data]
 		if linkValue then
-			return linkSer(buf, pos, size, linkValue, 32, 99, 132)
+			return linkSer(linkValue, buf, pos, size)
 		end
 		return numSer(data, buf, pos, size)
 	end,
 	vector = @native function(data: any, buf: buffer, pos: number, size: number)
 		local linkValue = link[data]
 		if linkValue then
-			return linkSer(buf, pos, size, linkValue, 32, 157, 190)
+			return linkSer(linkValue, buf, pos, size)
 		end
 		return vecSer(data, buf, pos, size)
 	end,
 	userdata = @native function(data: any, buf: buffer, pos: number, size: number)
 		local linkValue = link[data]
 		if linkValue then
-			return linkSer(buf, pos, size, linkValue, 16, 203, 220)
+			return linkSer(linkValue, buf, pos, size)
 		end
 		return userSer(data, buf, pos, size)
 	end,
@@ -197,21 +171,23 @@ function tabSerializer(
 		buf, pos, size, triggered = serialSwitch[typeName](data, buf, pos, size)
 
 		if pos - oldPos == 1 then
+			if triggered then
+				constants[data] = triggered
+				buf, pos, size = unlinkedSwitch[typeName](data, buf, pos, size)
+				return
+			end
+
 			local serValue = buffer.readu8(buf, oldPos)
 			constants[data] = serValue
-			if not triggered then
+		elseif pos - oldPos == 2 then
+			if triggered then
+				constants[data] = triggered
+				buf, pos, size = unlinkedSwitch[typeName](data, buf, pos, size)
 				return
 			end
 
-			buf, pos, size = unlinkedSwitch[typeName](data, buf, pos, size)
-		elseif pos - oldPos == 2 then
 			local serValue = buffer.readu16(buf, oldPos)
 			constants[data] = serValue
-			if not triggered then
-				return
-			end
-
-			buf, pos, size = unlinkedSwitch[typeName](data, buf, pos, size)
 		elseif data == data then
 			existingCache(data)
 		end
@@ -440,11 +416,13 @@ function tabDeserializer(buf: buffer, pos: number): ({ [any]: any }?, number)
 				or case == 4 and valId > 131
 				or case == 5 and valId > 189
 				or valId > 219
+
 			local pairedValue = paired[valId]
 			if pairedValue then
 				pos += if isTwo then 2 else 1
 				return pairedValue
 			end
+
 			-- read id, then skip to value
 			if isTwo then
 				local id = buffer.readu16(buf, pos)

--- a/src/table.luau
+++ b/src/table.luau
@@ -134,9 +134,35 @@ function tabSerializer(
 		buf, pos, size = serialSwitch[typeName](data, buf, pos, size)
 
 		if pos - oldPos == 1 then
-			constants[data] = buffer.readu8(buf, oldPos)
+			local serValue = buffer.readu8(buf, oldPos)
+			constants[data] = serValue
+			if
+				typeName == "string" and serValue > 13
+				or typeName == "number" and serValue > 96
+				or typeName == "vector" and serValue > 149
+				or typeName == "userdata" and serValue > 203
+			then
+				-- Bypasses the id, only happens once!
+				buf, pos, size =
+					serialSwitch[typeName](data, buf, pos, size, true)
+			end
 		elseif pos - oldPos == 2 then
-			constants[data] = buffer.readu16(buf, oldPos)
+			local serValue = buffer.readu16(buf, oldPos)
+			constants[data] = serValue
+
+			-- will change for reformatstringpack
+			-- string can never be 2 bytes currently except for pairs
+			if
+				typeName == "string"
+				or typeName == "number" and bit32.extract(serValue, 0, 8) > 90
+				or typeName == "vector"
+				or typeName == "userdata"
+					and bit32.extract(serValue, 0, 8) > 202
+			then
+				-- Bypasses the id, only happens once!
+				buf, pos, size =
+					serialSwitch[typeName](data, buf, pos, size, true)
+			end
 		elseif data == data then
 			existingCache(data)
 		end
@@ -311,6 +337,7 @@ function tabDeserializer(buf: buffer, pos: number): ({ [any]: any }?, number)
 	local existingIndex = 1
 	local existing: { [number]: any } = { [0] = returnedTab }
 	local roundRobinIndex = 61_440
+	local paired = {}
 
 	local deserialTable: (data: { [any]: any }) -> { [any]: any }?
 
@@ -353,6 +380,33 @@ function tabDeserializer(buf: buffer, pos: number): ({ [any]: any }?, number)
 			elseif valId <= 201 then 0 -- table (none currently that can get here)
 			elseif valId <= 223 then 6 -- userdata
 			else 0 -- for future
+
+		if
+			case == 3 and valId > 13
+			or case == 4 and valId > 96
+			or case == 5 and valId > 149
+			or case == 6 and valId > 203
+		then
+			local isTwo = case == 3 and valId > 82
+				or case == 4 and valId > 131
+				or case == 5 and valId > 189
+				or valId > 219
+			local pairedValue = paired[valId]
+			if pairedValue then
+				pos += if isTwo then 2 else 1
+				return pairedValue
+			end
+			-- read id, then skip to value
+			if isTwo then
+				local id = buffer.readu16(buf, pos)
+				value = deserialSwitch[case](buf, pos + 2)
+				paired[id] = value
+				return value
+			end
+			value = deserialSwitch[case](buf, pos + 1)
+			paired[valId] = value
+			return value
+		end
 
 		if case ~= 0 then
 			value, pos = deserialSwitch[case](buf, pos)

--- a/src/table.luau
+++ b/src/table.luau
@@ -399,11 +399,11 @@ function tabDeserializer(buf: buffer, pos: number): ({ [any]: any }?, number)
 			-- read id, then skip to value
 			if isTwo then
 				local id = buffer.readu16(buf, pos)
-				value = deserialSwitch[case](buf, pos + 2)
+				value, pos = deserialSwitch[case](buf, pos + 2)
 				paired[id] = value
 				return value
 			end
-			value = deserialSwitch[case](buf, pos + 1)
+			value, pos = deserialSwitch[case](buf, pos + 1)
 			paired[valId] = value
 			return value
 		end

--- a/src/userdata.luau
+++ b/src/userdata.luau
@@ -13,13 +13,11 @@ type Writer = (
 	size: number
 ) -> (buffer, number, number)
 
-local READ = {}
 local WRITE = {} -- 1 to 1039
 local Reader: Reader?
 local Writer: Writer?
 
 local Userdata = {
-	Read = READ,
 	Write = WRITE,
 	-- Need a way to set the approaches for serial and deserial
 
@@ -94,16 +92,6 @@ local Userdata = {
 	end,
 }
 
---[[
-	Clears and replaces the read table
-	
-	@ Mainly used to reduce memory usage
-]]
-function Userdata.resetRead()
-	table.clear(READ)
-	READ = {}
-	Userdata.Read = READ
-end
 --[[
 	Clears and replaces the write table
 	

--- a/src/userdata.luau
+++ b/src/userdata.luau
@@ -23,24 +23,32 @@ local Userdata = {
 	Write = WRITE,
 	-- Need a way to set the approaches for serial and deserial
 
-	serialize = function(value: any, buf: buffer, pos: number, size: number)
-		local cachedConstant: number? = WRITE[value]
-		if cachedConstant then
-			local newSize = if cachedConstant <= 16 then 1 else 2
+	serialize = function(
+		value: any,
+		buf: buffer,
+		pos: number,
+		size: number,
+		skipPairs: boolean?
+	)
+		if not skipPairs then
+			local cachedConstant: number? = WRITE[value]
+			if cachedConstant then
+				local newSize = if cachedConstant <= 16 then 1 else 2
 
-			if pos + newSize > size then
-				buf, size = inflate(buf, pos + newSize, size)
+				if pos + newSize > size then
+					buf, size = inflate(buf, pos + newSize, size)
+				end
+
+				if newSize == 1 then
+					buffer.writeu8(buf, pos, cachedConstant + 203)
+				else
+					local constVal = cachedConstant - 16
+					buffer.writeu8(buf, pos, 220 + (constVal // 256))
+					buffer.writeu8(buf, pos + 1, constVal)
+				end
+
+				return buf, pos + newSize, size
 			end
-
-			if newSize == 1 then
-				buffer.writeu8(buf, pos, cachedConstant + 203)
-			else
-				local constVal = cachedConstant - 16
-				buffer.writeu8(buf, pos, 220 + (constVal // 256))
-				buffer.writeu8(buf, pos + 1, constVal)
-			end
-
-			return buf, pos + newSize, size
 		end
 
 		if Writer then

--- a/src/userdata.luau
+++ b/src/userdata.luau
@@ -74,17 +74,6 @@ local Userdata = {
 	deserialize = function(buf: buffer, pos: number)
 		local id = buffer.readu8(buf, pos)
 
-		if id > 203 then
-			local cachedId = if id > 219
-				then (id - 220) * 256 + 16 + buffer.readu8(buf, pos + 1)
-				else id - 203
-
-			local cachedConstant = READ[cachedId]
-			if cachedConstant then
-				return cachedConstant, pos + (if cachedId > 16 then 2 else 1)
-			end
-		end
-
 		if Reader then
 			local obj
 			obj, pos = Reader(buf, pos + 1)

--- a/src/userdata.luau
+++ b/src/userdata.luau
@@ -13,42 +13,13 @@ type Writer = (
 	size: number
 ) -> (buffer, number, number)
 
-local WRITE = {} -- 1 to 1039
 local Reader: Reader?
 local Writer: Writer?
 
 local Userdata = {
-	Write = WRITE,
 	-- Need a way to set the approaches for serial and deserial
 
-	serialize = function(
-		value: any,
-		buf: buffer,
-		pos: number,
-		size: number,
-		skipPairs: boolean?
-	)
-		if not skipPairs then
-			local cachedConstant: number? = WRITE[value]
-			if cachedConstant then
-				local newSize = if cachedConstant <= 16 then 1 else 2
-
-				if pos + newSize > size then
-					buf, size = inflate(buf, pos + newSize, size)
-				end
-
-				if newSize == 1 then
-					buffer.writeu8(buf, pos, cachedConstant + 203)
-				else
-					local constVal = cachedConstant - 16
-					buffer.writeu8(buf, pos, 220 + (constVal // 256))
-					buffer.writeu8(buf, pos + 1, constVal)
-				end
-
-				return buf, pos + newSize, size
-			end
-		end
-
+	serialize = function(value: any, buf: buffer, pos: number, size: number)
 		if Writer then
 			if pos + 1 > size then
 				buf, size = inflate(buf, pos + 1, size)
@@ -91,16 +62,5 @@ local Userdata = {
 		Writer = writer
 	end,
 }
-
---[[
-	Clears and replaces the write table
-	
-	@ Mainly used to reduce memory usage
-]]
-function Userdata.resetWrite()
-	table.clear(WRITE)
-	WRITE = {}
-	Userdata.Write = WRITE
-end
 
 return Userdata

--- a/src/vector.luau
+++ b/src/vector.luau
@@ -238,17 +238,6 @@ local function vecDeserializer(buf: buffer, pos: number): (vector?, number)
 		return builtinDeserialConst[YZ_AXIS], pos + 1
 	end
 
-	if id > 157 then
-		local cachedId = if id > 189
-			then (id - 190) * 256 + 32 + buffer.readu8(buf, pos + 1)
-			else id - 157
-
-		local cachedConstant: vector? = READ[cachedId]
-		if cachedConstant then
-			return cachedConstant, pos + (if cachedId > 32 then 2 else 1)
-		end
-	end
-
 	if id == SCALAR_NUMBER then
 		local vecVal = builtinDeserialConst[buffer.readu8(buf, pos + 1)]
 		local numVal

--- a/src/vector.luau
+++ b/src/vector.luau
@@ -72,7 +72,8 @@ local function vecSerializer(
 	value: vector,
 	buf: buffer,
 	pos: number,
-	size: number
+	size: number,
+	skipPairs: boolean?
 )
 	local builtin: number? = builtinSerialConst[value]
 	if builtin then
@@ -83,23 +84,25 @@ local function vecSerializer(
 		return buf, pos + 1, size
 	end
 
-	local cachedConstant: number? = WRITE[value]
-	if cachedConstant then
-		local newSize = if cachedConstant <= 32 then 1 else 2
+	if not skipPairs then
+		local cachedConstant: number? = WRITE[value]
+		if cachedConstant then
+			local newSize = if cachedConstant <= 32 then 1 else 2
 
-		if pos + newSize > size then
-			buf, size = inflate(buf, pos + newSize, size)
+			if pos + newSize > size then
+				buf, size = inflate(buf, pos + newSize, size)
+			end
+
+			if newSize == 1 then
+				buffer.writeu8(buf, pos, cachedConstant + 157)
+			else
+				local constVal = cachedConstant - 32
+				buffer.writeu8(buf, pos, 190 + (constVal // 256))
+				buffer.writeu8(buf, pos + 1, constVal)
+			end
+
+			return buf, pos + newSize, size
 		end
-
-		if newSize == 1 then
-			buffer.writeu8(buf, pos, cachedConstant + 157)
-		else
-			local constVal = cachedConstant - 32
-			buffer.writeu8(buf, pos, 190 + (constVal // 256))
-			buffer.writeu8(buf, pos + 1, constVal)
-		end
-
-		return buf, pos + newSize, size
 	end
 
 	-- now we check scalar

--- a/src/vector.luau
+++ b/src/vector.luau
@@ -21,7 +21,6 @@ local FLOAT = 147
 local NUMBER = 148
 local SCALAR_NUMBER = 149
 
-local READ = {}
 local WRITE = {} -- 1 to 1055
 
 local builtinSerialConst = {
@@ -295,23 +294,12 @@ local function vecDeserializer(buf: buffer, pos: number): (vector?, number)
 end
 
 local Vector = {
-	Read = READ,
 	Write = WRITE,
 
 	serialize = vecSerializer,
 	deserialize = vecDeserializer,
 }
 
---[[
-	Clears and replaces the read table
-	
-	@ Mainly used to reduce memory usage
-]]
-function Vector.resetRead()
-	table.clear(READ)
-	READ = {}
-	Vector.Read = READ
-end
 --[[
 	Clears and replaces the write table
 	

--- a/src/vector.luau
+++ b/src/vector.luau
@@ -4,7 +4,7 @@ local inflate = require("./inflate")
 
 local numSerializer = require("./number").serialize
 local numDeserializer = require("./number").deserialize
-local numWrite = require("./number").Write
+local numWrite = require("./link") :: { number }
 
 local ZERO = 136
 local ONE = 137
@@ -20,8 +20,6 @@ local THREE_BYTE = 146
 local FLOAT = 147
 local NUMBER = 148
 local SCALAR_NUMBER = 149
-
-local WRITE = {} -- 1 to 1055
 
 local builtinSerialConst = {
 	-- Used for serialization
@@ -71,8 +69,7 @@ local function vecSerializer(
 	value: vector,
 	buf: buffer,
 	pos: number,
-	size: number,
-	skipPairs: boolean?
+	size: number
 )
 	local builtin: number? = builtinSerialConst[value]
 	if builtin then
@@ -81,27 +78,6 @@ local function vecSerializer(
 		end
 		buffer.writeu8(buf, pos, builtin)
 		return buf, pos + 1, size
-	end
-
-	if not skipPairs then
-		local cachedConstant: number? = WRITE[value]
-		if cachedConstant then
-			local newSize = if cachedConstant <= 32 then 1 else 2
-
-			if pos + newSize > size then
-				buf, size = inflate(buf, pos + newSize, size)
-			end
-
-			if newSize == 1 then
-				buffer.writeu8(buf, pos, cachedConstant + 157)
-			else
-				local constVal = cachedConstant - 32
-				buffer.writeu8(buf, pos, 190 + (constVal // 256))
-				buffer.writeu8(buf, pos + 1, constVal)
-			end
-
-			return buf, pos + newSize, size
-		end
 	end
 
 	-- now we check scalar
@@ -294,21 +270,8 @@ local function vecDeserializer(buf: buffer, pos: number): (vector?, number)
 end
 
 local Vector = {
-	Write = WRITE,
-
 	serialize = vecSerializer,
 	deserialize = vecDeserializer,
 }
-
---[[
-	Clears and replaces the write table
-	
-	@ Mainly used to reduce memory usage
-]]
-function Vector.resetWrite()
-	table.clear(WRITE)
-	WRITE = {}
-	Vector.Write = WRITE
-end
 
 return Vector

--- a/src/vector.luau
+++ b/src/vector.luau
@@ -4,7 +4,7 @@ local inflate = require("./inflate")
 
 local numSerializer = require("./number").serialize
 local numDeserializer = require("./number").deserialize
-local numWrite = require("./link") :: { number }
+local numWrite = require("./link").values :: { number }
 
 local ZERO = 136
 local ONE = 137


### PR DESCRIPTION
# Patch for Pairs

As discussed in #36, `pairs` causes mental strain on users since they need to consider migration impacts when using.  The goal of this PR is to remove all migration concerns surrounding `pairs` by storing the Id-Value pair within the serialized data.  Efficiently.

Closes #36
