### PR TITLE
Remove pairs from Number vectors

### DIFF
--- a/src/vector.luau
+++ b/src/vector.luau
@@ -4,7 +4,6 @@ local inflate = require("./inflate")
 
 local numSerializer = require("./number").serialize
 local numDeserializer = require("./number").deserialize
-local numWrite = require("./link").values :: { number }
 
 local ZERO = 136
 local ONE = 137
@@ -145,12 +144,6 @@ local function vecSerializer(
 	if not isNumber then
 		typeZ = getType(valueZ)
 		isNumber = typeY ~= typeZ
-	end
-	if not isNumber and typeX ~= BYTE then
-		-- if num is a constant and all types aren't byte
-		-- char/tryte COULD be cheaper (1 + 2 (const) + 5 (float) + 5 (float) is worst case)
-		-- the checks are VERY expensive (from a line perspective) though
-		isNumber = (numWrite[valueX] or numWrite[valueY] or numWrite[valueZ])
 	end
 
 	-- 4+ bytes (NOT intelligent, as a const byte will be more expensive)


### PR DESCRIPTION
# Enhancement Pull Request

## Summary

Vector previously allowed for paired numbers to result in smaller output sizes for vectors.  Due to the removal of immediate value to id serialization, the benefits no longer outweigh the costs.  As such, removal should occur of the feature that relied on `pairs` to improve number vectors.

## Motivation

Due to migration concerns surrounding `pairs`, all mentions are being re-thought.  The prior code causes slight performance impacts and no longer benefits from the reduced output size `pairs` provided.

Vector prior allowed for: 1 + ID + ID + ID (4 bytes) to 1 + 4 + 5 + 5 (15 bytes).  However, since number must be stored with the id, at least initially, we must take into account more information.  Vectors now, assuming no knowledge on whether number has been stored prior, are: 1 + ID + 1 + 2 + 2 (7 bytes) to 1 + ID + 4 + ID + 4 + ID + 4 (19 bytes).

- Has the paired number been serialized prior, if so, we should choose the cheapest output size path for the three values.
    - If not, is it worth the cost?

Such considerations are valuable, but add significant complexity to vector serialization.  As such, they will be forgone until a later version, should adequate benefit exist.  For extenders that heavily use vectors, the provided will be ideal from a performance standpoint, but from an output size standpoint is quite lacking.