### PR TITLE
Userdata is no longer stored in the existing table

### DIFF
--- a/src/table.luau
+++ b/src/table.luau
@@ -192,7 +192,7 @@ function tabSerializer(
 
 			local serValue = buffer.readu16(buf, oldPos)
 			constants[data] = serValue
-		elseif data == data then
+		elseif data == data and typeName ~= "userdata" then
 			existingCache(data)
 		end
 	end
@@ -400,7 +400,7 @@ function tabDeserializer(buf: buffer, pos: number): ({ [any]: any }?, number)
 			return nil -- data corrupted
 		end
 
-		if pos - 2 > oldPos then
+		if pos - 2 > oldPos and case ~= "userdata" then
 			existingCache(value)
 		end
 		return value


### PR DESCRIPTION
## Summary

When saving an identical userdata, it will no longer be 3 bytes, benefit of existing table.

## Motivation

Userdata is highly likely of being different from other userdata, causing the existing table, whose limit is 61k unique values, with 4k cycling in a round-robin, to quickly fill up.  The first and largest section of the existing table should hold the most important values, preferably, aside from pairs.

Userdata has mixed approaches in how it is created and passed around.  Some embedders/developers cache a small subset of the applicable userdata, whereas others constantly create new userdata objects.  There is no way to determine, while cached userdata has the potential to benefit, the other has none.

For tables densely populated with userdata, the existing table **could** fill quickly and result in larger output sizes.  In reality, such a situation is rare, and even then the round robin approach will allow for an adequate reduction in output size.

**Pros:**

- More existing table space for the more common types.
- Large tables with userdata could have smaller output sizes

**Cons:**

- When serializing large tables full of equal userdata, it becomes incredibly slow.  An alternative is to pair the userdata, but only so many can be paired.
- More logic to document and for implementers to abide by and for users to understand.
- More logic to create for users of userdata if they want the performance to be reasonable.

**Alternatives**
- Do nothing.  Much like tables, continue to let userdata fill the existing table with references that have a chance of being duplicates.