### PR TITLE
Added a release system

### DIFF
--- a/tools/release.luau
+++ b/tools/release.luau
@@ -5,8 +5,9 @@ local release = {}
 
 	To run:
 	cd to/repo/path
-	lune run tools/release.luau TAG \
-		--build
+	lune run tools/release.luau 1.2.3 \
+		--build \
+		--prefix=BufferSerializer
 
 	Alternative:
 	cd to/repo/path
@@ -20,9 +21,15 @@ local release = {}
 local process = require("@lune/process")
 local args = process.args
 
+local function pathName(path: string)
+	local pathSplit = string.split(path, "/")
+	return pathSplit[#pathSplit - 1]
+end
+
 local options = {
 	build = false,
 	tag = "",
+	prefix = pathName(process.cwd),
 }
 
 function printHelp()
@@ -33,6 +40,7 @@ Usage: %s <tag> [options]
 Available options:
   -h, --help: Display this usage message
   --build: Uses build.luau to build
+  --prefix<=str>: The prefix of the file to publish, default is directory name
 	]],
 		process.env._
 	))
@@ -42,6 +50,10 @@ for _, input in args do
 	if input == "-h" or input == "--help" then
 		printHelp()
 		process.exit(0)
+	end
+	if input:sub(1, 9) == "--prefix=" then
+		options.prefix = input:sub(8)
+		continue
 	end
 	if input == "--build" then
 		options.build = true
@@ -59,7 +71,7 @@ if options.build then
 	process.exec("lune", {
 		"run",
 		"tools/build.luau",
-		"--name=BufferSerializer" .. options.tag,
+		`--name={options.prefix}{options.tag}`,
 	})
 end
 
@@ -73,7 +85,7 @@ local ghRelease = process.exec("gh", {
 	"--fail-on-no-commits",
 	"--title",
 	`Version {options.tag}`,
-	`BufferSerializer{options.tag}.rbxm`,
+	`{options.prefix}{options.tag}.rbxm`,
 })
 print(ghRelease.stderr)
 


### PR DESCRIPTION
## Summary

Adds a tool for releasing builds in a consistent manner.

## Motivation

Creating a release is a multi-step process that is too complex to perform regularly.  As such, using the build tool from #44, Lune, and the Github CLI, we can transform a multi-step process into running a single simple command: `lune run tools/release.luau TAG --build`.

The tool is useful for those contributing, if they want to roll their own.