### PR TITLE
Improve reducing output size docs

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -13,7 +13,7 @@ When migrating, the following steps are used.
    - Reductions are often reflected in BufferSerializer.
 
 2. Pair frequently used values.  For more information
- see [pairs](./docs/code/README.md).
+ see [pairs](https://github.com/nwinn-student/luau-buffer-serialize/blob/main/docs/code/README.md).
 
 3. Convert strings that can be expressed as unions into numbers, identifiers.
    - A `Greeting` union would be "Hello" -> 1, "Hey" -> 2, "What's up" -> 3, etc.


### PR DESCRIPTION
The documentation for reducing output size was incomplete.  This PR guides users in a more generalized fashion.