### PR TITLE
Update risk docs

### DIFF
--- a/docs/risks.md
+++ b/docs/risks.md
@@ -1,4 +1,40 @@
+# Risks
+
+This document outlines potential risks associated with the serialization and
+ deserialization of data structures, particularly in the context of the
+ BufferSerializer library. It is crucial to understand these risks to mitigate
+ potential vulnerabilities in applications that utilize these techniques.
+
+### Back References
+
+There are two approaches that rely on the order of data serialized.  The
+ first being `equal_existing` and the second being `pairs`.
+
+The `equal_existing` byte is defined as a way to store a prior unique
+ value in a compressed form.  That is, all unique values are input into a
+ cache and numbered, should the value appear again, the number associated
+ with the value in the cache will be stored.
+
+An attacker could modify the number attached to the `equal_existing`
+ byte to reference a prior unique value.  The resulting behavior is that
+ the attacker could cause an error or freeze to occur when handling the
+ deserialized form.
+
+The `pairs` bytes rely on the first value, and all identifiers
+ technically point to this value and pull it in.  Should the value
+ be modified, deserialization will pass.  As with `equal_existing`,
+ the attacker could cause errors or freezes to occur.
+
+The recommended solution in both cases is to use standard
+ security practices when handling the data.
+
+#### Userdata Custom Approach
+
+Requires careful handling to ensure custom serialization and
+ deserialization functions are compatible.
+
 #### Limitations
+
 - Although cyclic tables<sup>[1]</sup> are supported, large datasets with
   distant<sup>[2]</sup> cyclic tables will fatally error.  Although possible,
   the solution would be too costly.


### PR DESCRIPTION
Closes #20

There is a stale PR that cannot get accepted due to docs conflicts.  This PR takes the ideas from the stale PR and updates the risk documentation to include them.

The risk documention needed to include the security risks associated with `equal_existing` and `pairs`.