### PR TITLE
Vector should not go past 13 bytes

### DIFF
--- a/src/vector.luau
+++ b/src/vector.luau
@@ -144,6 +144,17 @@ local function vecSerializer(
 	if not isNumber then
 		typeZ = getType(valueZ)
 		isNumber = typeY ~= typeZ
+		if
+        isNumber
+        and (typeX == FLOAT
+        or typeY == FLOAT
+        or typeZ == FLOAT)
+    then
+        -- fft = 15, ftt = 14
+        -- so no floats
+        typeX = FLOAT
+        isNumber = false
+    end
 	end
 
 	-- 4+ bytes (NOT intelligent, as a const byte will be more expensive)


### PR DESCRIPTION
For certain combinations of types for multi-set or number vectors (FFT and FTT) the cost was more than 13.  The solution was to say that if ANY of the values are floats it cannot be a number AND the type is floats.