### PR TITLE
Improve the constant example

### DIFF
--- a/examples/constant.luau
+++ b/examples/constant.luau
@@ -28,7 +28,7 @@ end
 
 local data = {}
 
-for i=0, 100 do
+for i=0, 30 do
     table.insert(data, GenerateFruit())
 end
 


### PR DESCRIPTION
A better example using pairs has been provided.  The prior one did not showcase the common usage case, instead it just made a dataset more expensive.