### PR TITLE
Swap params in test.serial

### DIFF
--- a/test/test.luau
+++ b/test/test.luau
@@ -96,7 +96,7 @@ local test = {
 		end
 		return buf
 	end,
-	serial = function(ori: buffer, new: buffer)
+	serial = function(new: buffer, ori: buffer)
 		local testFail = false
 
 		local oriSize = buffer.len(ori)


### PR DESCRIPTION
Gives a clearer output when testing different versions.

Closes #72.