### PR TITLE
Vector Number Float Revert (max 13)

### DIFF
--- a/src/vector.luau
+++ b/src/vector.luau
@@ -143,16 +143,16 @@ local function vecSerializer(
 		if isNumber and (typeX == FLOAT or typeY == FLOAT or typeZ == FLOAT) then
 			-- fft = 15, ftt = 14, ffc = 14
 			-- so no floats and trytes
-			local hasTryte = typeX == THREE_BYTE or typeY == THREE_BYTE or typeZ == THREE_BYTE
+			local hasTryte = typeX == THREE_BYTE
+				or typeY == THREE_BYTE
+				or typeZ == THREE_BYTE
 			local hasChar = typeX == CHAR or typeY == CHAR or typeZ == CHAR
 			local twoFloat = typeX == FLOAT and (typeX == typeY or typeX == typeZ)
 				or (typeY == FLOAT and typeY == typeZ)
-			local twoTryte = typeX == THREE_BYTE and (typeX == typeY or typeX == typeZ)
+			local twoTryte = typeX == THREE_BYTE
+					and (typeX == typeY or typeX == typeZ)
 				or (typeY == THREE_BYTE and typeY == typeZ)
-			if (hasTryte and twoFloat)
-				or (hasChar and twoFloat)
-				or twoTryte
-			then
+			if (hasTryte and twoFloat) or (hasChar and twoFloat) or twoTryte then
 				typeX = FLOAT
 				isNumber = false
 			end


### PR DESCRIPTION
In a prior PR (#69), we said that if the number in a vector was a float, and it could be stored as a vector number, it will be stored as a vector float instead.  The PR used FTT and FFT as examples, however they forgot about FFC.  These are the only 3 cases that are more expensive than 13 bytes.

There are many other cases that are as cheap or cheaper than 13 bytes, that include float.

This PR takes back the notion that floats are the issue and instead targets the three cases.