### PR TITLE
Fix Table Replaces old Buffer

### DIFF
--- a/src/table.luau
+++ b/src/table.luau
@@ -127,7 +127,9 @@ function tabSerializer(
 
 	local serialTable: (data: { [any]: any }) -> ()
 
-	buf, size = buffer.create(64), 64
+	if size == 0 then
+		buf, size = buffer.create(64), 64
+	end
 
 	@native
 	local function existingCache(data: any)


### PR DESCRIPTION
Closes #93

The bug only impacts userdata and custom usages of table.serialize.