### PR TITLE
Generate scripts for benchmarking

### DIFF
--- a/tools/benchmark/init.luau
+++ b/tools/benchmark/init.luau
@@ -49,8 +49,8 @@ local options: CommandOptions = {
 	output = "benchmark-results.json",
 }
 local validatePreBenchData: (BenchData) -> (boolean, string) = t.strictInterface({
-	time = t.strictArray(t.number),
-	space = t.strictArray(t.number),
+	time = t.array(t.number),
+	space = t.array(t.number),
 	metadata = t.optional(t.map(t.string, t.any)),
 })
 

--- a/tools/benchmark/t.luau
+++ b/tools/benchmark/t.luau
@@ -291,48 +291,6 @@ do
 			return true
 		end
 	end
-
-	--[[**
-		ensures value is an array of a strict makeup and size
-
-		@param check The check to compare all values with
-
-		@returns A function that will return true iff the condition is passed
-	**--]]
-	function t.strictArray(...)
-		local valueTypes = { ... }
-		assert(t.array(t.callback)(valueTypes))
-
-		return function(value)
-			local keySuccess, keyErrMsg = arrayKeysCheck(value)
-			if keySuccess == false then
-				return false, string.format("[strictArray] %s", keyErrMsg or "")
-			end
-
-			-- If there's more than the set array size, disallow
-			if #valueTypes < #value then
-				return false,
-					string.format(
-						"[strictArray] Array size exceeds limit of %d",
-						#valueTypes
-					)
-			end
-
-			for idx, typeFn in pairs(valueTypes) do
-				local typeSuccess, typeErrMsg = typeFn(value[idx])
-				if not typeSuccess then
-					return false,
-						string.format(
-							"[strictArray] Array index #%d - %s",
-							idx,
-							typeErrMsg
-						)
-				end
-			end
-
-			return true
-		end
-	end
 end
 
 --[[**

--- a/tools/fetch-resources.luau
+++ b/tools/fetch-resources.luau
@@ -10,7 +10,8 @@
 
 	Places the resources in the resources directory.
 	- /resources
-	 - /datasets
+	 - pokedex.json
+	 - /size_datasets
 	 - /luau-bench
 	 - /BufferSerializer/{VERSION_TAG}
 
@@ -156,8 +157,8 @@ local function set_content(
 	end)
 end
 
-local function fetch_dataset(): ()
-	print("FETCHING DATASET...")
+local function fetch_size_datasets(): ()
+	print("FETCHING SIZE DATASETS...")
 
 	local success: boolean, dataset_result =
 		pcall(ghrequest, "benchmark", datasets_root)
@@ -168,26 +169,39 @@ local function fetch_dataset(): ()
 
 	local datasetDirs = serde.decode("json", dataset_result.body)
 
-	if not fs.isDir("resources/datasets") then
-		fs.writeDir("resources/datasets")
+	if not fs.isDir("resources/size_datasets") then
+		fs.writeDir("resources/size_datasets")
 	end
 
 	-- The dataset repo is a public archive, so we can make the
 	-- assumption that all file locations are stationary
 
 	for _, dir: GitHubResult in datasetDirs do
-		if not fs.isDir(`resources/datasets/{dir.name}`) then
-			fs.writeDir(`resources/datasets/{dir.name}`)
+		if not fs.isDir(`resources/size_datasets/{dir.name}`) then
+			fs.writeDir(`resources/size_datasets/{dir.name}`)
 		end
 
 		local data_url: string = `{raw_datasets_root}/{dir.path}/document.json`
 		local taxonomy_url: string = `{raw_datasets_root}/{dir.path}/TAXONOMY`
 		local source_url: string = `{raw_datasets_root}/{dir.path}/SOURCE`
 
-		set_content(`resources/datasets/{dir.name}/document.json`, data_url)
-		set_content(`resources/datasets/{dir.name}/TAXONOMY`, taxonomy_url)
-		set_content(`resources/datasets/{dir.name}/SOURCE`, source_url)
+		set_content(`resources/size_datasets/{dir.name}/document.json`, data_url)
+		set_content(`resources/size_datasets/{dir.name}/TAXONOMY`, taxonomy_url)
+		set_content(`resources/size_datasets/{dir.name}/SOURCE`, source_url)
 	end
+end
+
+local function fetch_pokedex_dataset(): ()
+	print("FETCHING POKEDEX DATASET...")
+
+	-- Note: We are using a blob link instead of the actual link:
+	-- https://raw.githubusercontent.com/Biuni/PokemonGO-Pokedex/master/pokedex.json
+	-- to avoid cases where the user is comprimised and the json is modified.
+
+	set_content(
+		"resources/pokedex.json",
+		"https://raw.githubusercontent.com/Biuni/PokemonGO-Pokedex/ee19a4e93d9df10783a4d04c5245ab4cb8810861/pokedex.json"
+	)
 end
 
 local function fetch_bench(): ()
@@ -231,7 +245,8 @@ if not fs.isDir("resources") then
 end
 
 if not options.exclude_datasets then
-	fetch_dataset()
+	fetch_size_datasets()
+	fetch_pokedex_dataset()
 end
 
 if not options.exclude_bench then

--- a/tools/generate-scripts.luau
+++ b/tools/generate-scripts.luau
@@ -1,9 +1,9 @@
 --[[
-	Creates a directory in results/ with the given name.
+	Creates a directory with the given structure.
 	- results
 	 - /BufferSerializer
 	 - .luaurc
-	  - /vN
+	  - /vN -- version
 	   - .luaurc
 	   - serialize.luau
 	   - deserialize.luau
@@ -20,10 +20,6 @@ local fs = require("@lune/fs")
 local process = require("@lune/process")
 local serde = require("@lune/serde")
 
-local options = {
-	versions = {},
-}
-
 function cli_assert(cond: any, message: string): ()
 	if not cond then
 		print(message)
@@ -32,17 +28,23 @@ function cli_assert(cond: any, message: string): ()
 end
 
 function printHelp(): ()
-	print(string.format(
-		[[
-Usage: %s [options]
+	print([[
+Usage: lune run tools/generate-scripts
+
+Creates a directory with the given structure.
+	- results
+	 - /BufferSerializer
+	 - .luaurc
+	  - /vN -- version
+	   - .luaurc
+	   - serialize.luau
+	   - deserialize.luau
+       - /size
+        - /... -- 1 script per size_dataset
 
 Available options:
   -h, --help: Display this usage message
-  --verisons=<tag[,tag]>: Generates time/space benchmark scripts for the provided versions
-      ALL can be used to generate all downloaded versions.
-	]],
-		process.env._
-	))
+	]])
 end
 
 if not fs.isDir("results") or not fs.isDir("results/BufferSerializer") then
@@ -68,22 +70,20 @@ cli_assert(
 	fs.isDir("resources/size_datasets"),
 	"resources/size_datasets directory must exist"
 )
+cli_assert(
+	fs.isDir("resources/BufferSerializer"),
+	"resources/BufferSerializer directory must exist when generating version scripts"
+)
 
 for _, input: string in process.args do
 	if input == "-h" or input == "--help" then
 		printHelp()
 		process.exit(0)
 	end
-	if input:sub(1, 11) == "--versions=" then
-		options.versions = input:sub(12):split(",")
-		continue
-	end
 	print(`{input} is not a valid command, see help:`)
 	printHelp()
 	process.exit(0)
 end
-
--- [[ GENERATE SERIALIZE ]]
 
 function get_serialize(): string
 	return [[-- serialize
@@ -119,8 +119,6 @@ return {
 }
 ]]
 end
-
--- [[ GENERATE DESERIALIZE ]]
 
 function get_deserialize(): string
 	return [[-- deserialize
@@ -234,20 +232,7 @@ local function gen_version(version: string)
 	)
 end
 
-for _, version: string in options.versions do
-	if version == "ALL" then
-		cli_assert(
-			fs.isDir("resources/BufferSerializer"),
-			"resources/BufferSerializer directory must exist when generating version scripts"
-		)
-
-		for _, version: string in fs.readDir("resources/BufferSerializer") do
-			gen_version(version)
-		end
-
-		break
-	end
-
+for _, version: string in fs.readDir("resources/BufferSerializer") do
 	gen_version(version)
 end
 

--- a/tools/generate-scripts.luau
+++ b/tools/generate-scripts.luau
@@ -172,8 +172,8 @@ local rawdata = serde.decode("json", fs.readFile("resources/size_datasets/%s/doc
 local data = format.serialize(rawdata)
 
 return {
-	time = {},
-	space = {},
+	time = { 0 },
+	space = { 0 },
 	metadata = {
 		taxonomy = "%s",
 		size = buffer.len(data),

--- a/tools/generate-scripts.luau
+++ b/tools/generate-scripts.luau
@@ -1,0 +1,256 @@
+--[[
+	Creates a directory in results/ with the given name.
+	- results
+	 - /BufferSerializer
+	 - .luaurc
+	  - /vN
+	   - .luaurc
+	   - serialize.luau
+	   - deserialize.luau
+       - /size
+        - /... -- 1 script per size_dataset
+
+	To run:
+	cd to/repo/path
+
+	lune run tools/generate-scripts
+]]
+
+local fs = require("@lune/fs")
+local process = require("@lune/process")
+local serde = require("@lune/serde")
+
+local options = {
+	versions = {},
+}
+
+function cli_assert(cond: any, message: string): ()
+	if not cond then
+		print(message)
+		process.exit(0)
+	end
+end
+
+function printHelp(): ()
+	print(string.format(
+		[[
+Usage: %s [options]
+
+Available options:
+  -h, --help: Display this usage message
+  --verisons=<tag[,tag]>: Generates time/space benchmark scripts for the provided versions
+      ALL can be used to generate all downloaded versions.
+	]],
+		process.env._
+	))
+end
+
+if not fs.isDir("results") or not fs.isDir("results/BufferSerializer") then
+	fs.writeDir("results/BufferSerializer")
+end
+
+if not fs.isFile("results/.luaurc") then
+	local config = {
+		aliases = {
+			resources = "../resources",
+		},
+	}
+	fs.writeFile("results/.luaurc", serde.encode("json", config, true))
+end
+
+cli_assert(fs.isDir("resources"), "resources directory must exist")
+
+cli_assert(
+	fs.isDir("resources/size_datasets"),
+	"resources/size_datasets directory must exist"
+)
+cli_assert(
+	fs.isDir("resources/size_datasets"),
+	"resources/size_datasets directory must exist"
+)
+
+for _, input: string in process.args do
+	if input == "-h" or input == "--help" then
+		printHelp()
+		process.exit(0)
+	end
+	if input:sub(1, 11) == "--versions=" then
+		options.versions = input:sub(12):split(",")
+		continue
+	end
+	print(`{input} is not a valid command, see help:`)
+	printHelp()
+	process.exit(0)
+end
+
+-- [[ GENERATE SERIALIZE ]]
+
+function get_serialize(): string
+	return [[-- serialize
+local Bench = require("@resources/luau-bench")
+local format = require("@BufferSerializer")
+local fs = require("@lune/fs")
+local serde = require("@lune/serde")
+
+local rawdata = {}
+do
+	local file_name = "resources/pokedex.json"
+	assert(fs.isFile(file_name), `{file_name} does not exist`)
+	local success, file_data = pcall(serde.decode, "json", fs.readFile(file_name))
+	assert(success, `{file_name} could not be parsed`)
+	rawdata = file_data
+end
+
+local benchData = Bench(format.serialize, rawdata):updateOutput(function(output)
+	if type(output) == "string" then
+		return string.len(output)
+	elseif type(output) == "buffer" then
+		return buffer.len(output)
+	end
+	return
+end)
+
+return {
+	time = benchData.Speed.Data,
+	space = benchData.Memory.Data,
+	metadata = {
+		size = benchData.Output,
+	},
+}
+]]
+end
+
+-- [[ GENERATE DESERIALIZE ]]
+
+function get_deserialize(): string
+	return [[-- deserialize
+local Bench = require("@resources/luau-bench")
+local format = require("@BufferSerializer")
+local fs = require("@lune/fs")
+local serde = require("@lune/serde")
+
+local rawdata = {}
+do
+	local file_name = "resources/pokedex.json"
+	assert(fs.isFile(file_name), `{file_name} does not exist`)
+	local success, file_data = pcall(serde.decode, "json", fs.readFile(file_name))
+	assert(success, `{file_name} could not be parsed`)
+	rawdata = file_data
+end
+
+local benchData = Bench(
+	format.deserialize,
+	format.serialize(rawdata)
+):updateOutput()
+
+return {
+	time = benchData.Speed.Data,
+	space = benchData.Memory.Data,
+	metadata = {},
+}
+]]
+end
+
+-- [[ GENERATE SIZE ]]
+
+for _, path: string in fs.readDir("resources/size_datasets") do
+	cli_assert(
+		fs.isDir(
+			`resources/size_datasets/{path}`,
+			`resources/size_datasets/{path} must be a directory`
+		)
+	)
+	cli_assert(
+		fs.isFile(`resources/size_datasets/{path}/TAXONOMY`),
+		`resources/size_datasets/{path}/TAXONOMY must exist`
+	)
+	local contents: string = string.format(
+		[[-- size
+local format = require("@BufferSerializer")
+local fs = require("@lune/fs")
+local serde = require("@lune/serde")
+
+local rawdata = serde.decode("json", fs.readFile("resources/size_datasets/%s/document.json"))
+local data = format.serialize(rawdata)
+
+return {
+	time = {},
+	space = {},
+	metadata = {
+		taxonomy = "%s",
+		size = buffer.len(data),
+		compression = {
+			gzip = #serde.compress("gzip", data, 9),
+			lz4 = #serde.compress("lz4", data, 9),
+		},
+	}
+}
+	]],
+		path,
+		fs.readFile(`resources/size_datasets/{path}/TAXONOMY`):sub(1, -2)
+	)
+
+	if not fs.isDir(`results/BufferSerializer/size}`) then
+		fs.writeDir(`results/BufferSerializer/size`)
+	end
+	fs.writeFile(`results/BufferSerializer/size/{path}.luau`, contents)
+end
+
+local function gen_version(version: string)
+	cli_assert(
+		fs.isDir(`resources/BufferSerializer/{version}`),
+		`resources/BufferSerializer/{version} must be a directory`
+	)
+
+	if not fs.isDir(`results/BufferSerializer/{version}`) then
+		fs.writeDir(`results/BufferSerializer/{version}`)
+	end
+
+	local path: string = `../../../resources/BufferSerializer/{version}`
+
+	fs.writeFile(
+		`results/BufferSerializer/{version}/serialize.luau`,
+		get_serialize()
+	)
+	fs.writeFile(
+		`results/BufferSerializer/{version}/deserialize.luau`,
+		get_deserialize()
+	)
+
+	local size_from: string = "results/BufferSerializer/size"
+	local size_to: string = `results/BufferSerializer/{version}/size`
+
+	fs.copy(size_from, size_to, true)
+
+	local contents = {
+		aliases = {
+			BufferSerializer = path,
+		},
+	}
+
+	fs.writeFile(
+		`results/BufferSerializer/{version}/.luaurc`,
+		serde.encode("json", contents, true)
+	)
+end
+
+for _, version: string in options.versions do
+	if version == "ALL" then
+		cli_assert(
+			fs.isDir("resources/BufferSerializer"),
+			"resources/BufferSerializer directory must exist when generating version scripts"
+		)
+
+		for _, version: string in fs.readDir("resources/BufferSerializer") do
+			gen_version(version)
+		end
+
+		break
+	end
+
+	gen_version(version)
+end
+
+fs.removeDir(`results/BufferSerializer/size`)
+
+return {}


### PR DESCRIPTION
Adds `tools/generate-scripts` for generating the relevant benchmark scripts.

For future tool usage, the location and structure of the scripts are as follows:
```terminaloutput
results
- .luaurc -- has @resources
- BufferSerializer
-- {version} -- one per version
--- .luaurc -- has @BufferSerializer
--- serialize.luau -- time/space
--- deserialize.luau -- time/space
--- size
---- {dataset}.luau -- one script per dataset in size_datasets
```