### PR TITLE
Unsupported ud keys

### DIFF
--- a/docs/code/README.md
+++ b/docs/code/README.md
@@ -152,7 +152,7 @@ local serialData = BufferSerializer.serialize(sample_userdata)
 
 Returns whether the userdata is capable of being serialized and deserialized.
 
-- Meaning the userdata does not deserialize into the unsupported userdata constant.
+- Meaning the userdata does not deserialize into an unsupported userdata.
 
 **Recommendations:**
 - Ensure the userdata deserializes into the desired form.

--- a/docs/spec/format.md
+++ b/docs/spec/format.md
@@ -107,7 +107,7 @@ Vectors have multiple modes: scalar multiple, multi-set (byte, char, tryte), and
 | 200     | 1        | `table`    | Table terminator                            |
 | 201     | 1        | `table`    | **Unknown**                                 |
 | 202     | 1 + size | `userdata` | Custom userdata                             |
-| 203     | 1        | `userdata` | A constant value for unsupported userdata   |
+| 203     | 1        | `userdata` | Represents all unsupported userdata         |
 | 204-213 | 1        | `userdata` | [Legacy] The id for a paired userdata value |
 | 214-215 | 2        | `userdata` | [Legacy] The id for a paired userdata value |
 | 216-239 | 0        | `future`   | Reserved for new types or expansions        |

--- a/src/init.luau
+++ b/src/init.luau
@@ -223,7 +223,7 @@ end
 --[[
 	Returns whether the userdata is capable of being serialized and deserialized.
 
-	- Meaning the userdata does not deserialize into the unsupported userdata constant
+	- Meaning the userdata does not deserialize into an unsupported userdata.
 
 	**Recommendations:**
 	- Ensure the userdata deserializes into the desired form.
@@ -235,11 +235,12 @@ end
 	@error buffer access out of bounds
 ]]
 function BufferSerializer.isSupported(ud: any): boolean
-	if ud == userdata.unsupported then
+	if userdata.isUnsupported(ud) then
 		return false
 	end
-	return userdata.deserialize(userdata.serialize(ud, buffer.create(0), 0), 0)
-		~= userdata.unsupported
+	local new_udata =
+		userdata.deserialize(userdata.serialize(ud, buffer.create(0), 0), 0)
+	return not userdata.isUnsupported(new_udata)
 end
 
 return table.freeze(BufferSerializer)

--- a/src/init.luau
+++ b/src/init.luau
@@ -235,12 +235,11 @@ end
 	@error buffer access out of bounds
 ]]
 function BufferSerializer.isSupported(ud: any): boolean
-	if userdata.isUnsupported(ud) then
-		return false
-	end
-	local new_udata =
-		userdata.deserialize(userdata.serialize(ud, buffer.create(0), 0), 0)
-	return not userdata.isUnsupported(new_udata)
+	local buf, pos = userdata.serialize(ud, buffer.create(0), 0)
+
+	userdata.deserialize(buf, 0)
+	-- Only unsupported userdata can return pos == 1
+	return pos ~= 1
 end
 
 return table.freeze(BufferSerializer)

--- a/src/userdata.luau
+++ b/src/userdata.luau
@@ -14,8 +14,6 @@ type Support = {
 	deserialize: (buf: buffer, pos: number) -> (any?, number),
 }
 
-local UNSUPPORTED_USERDATA = setmetatable({}, { __mode = "ks" })
-
 local supports = {
 	serializers = {},
 	deserializers = {},
@@ -74,7 +72,6 @@ local function userDeserializer(buf: buffer, pos: number)
 
 	if id == UNSUPPORTED then
 		local unsupported = newproxy()
-		UNSUPPORTED_USERDATA[unsupported] = true
 		return unsupported, pos + 1
 	end
 
@@ -197,15 +194,10 @@ function addSupport(record: Support)
 	end
 end
 
-function isUnsupported(udata: unknown)
-	return UNSUPPORTED_USERDATA[udata] == true
-end
-
 local Userdata = {
 	serialize = userSerializer,
 	deserialize = userDeserializer,
 	addSupport = addSupport,
-	isUnsupported = isUnsupported,
 }
 
 return table.freeze(Userdata)

--- a/src/userdata.luau
+++ b/src/userdata.luau
@@ -14,7 +14,7 @@ type Support = {
 	deserialize: (buf: buffer, pos: number) -> (any?, number),
 }
 
-local UNSUPPORTED_USERDATA = newproxy()
+local UNSUPPORTED_USERDATA = setmetatable({}, { __mode = "ks" })
 
 local supports = {
 	serializers = {},
@@ -28,7 +28,7 @@ local function writeUnsupported(buf: buffer, pos: number)
 end
 
 local function userSerializer(value: any, buf: buffer, pos: number)
-	if #supports.serializers == 0 or value == UNSUPPORTED_USERDATA then
+	if #supports.serializers == 0 then
 		return writeUnsupported(buf, pos)
 	end
 
@@ -73,7 +73,9 @@ local function userDeserializer(buf: buffer, pos: number)
 	local id = buffer.readu8(buf, pos)
 
 	if id == UNSUPPORTED then
-		return UNSUPPORTED_USERDATA, pos + 1
+		local unsupported = newproxy()
+		UNSUPPORTED_USERDATA[unsupported] = true
+		return unsupported, pos + 1
 	end
 
 	if id ~= CUSTOM then
@@ -195,12 +197,15 @@ function addSupport(record: Support)
 	end
 end
 
+function isUnsupported(udata: unknown)
+	return UNSUPPORTED_USERDATA[udata] == true
+end
+
 local Userdata = {
 	serialize = userSerializer,
 	deserialize = userDeserializer,
 	addSupport = addSupport,
-
-	unsupported = UNSUPPORTED_USERDATA,
+	isUnsupported = isUnsupported,
 }
 
 return table.freeze(Userdata)

--- a/src/userdata.luau
+++ b/src/userdata.luau
@@ -135,12 +135,12 @@ end
 	local sample_id = 0
 
 	BufferSerializer.supportUserdata({
-		serialize = function(value: any, buf: buffer, pos: number, size: number)
+		serialize = function(value: any, buf: buffer, pos: number)
 			if value ~= sample_userdata then
-				return buf, pos, size
+				return buf, pos
 			end
 			buffer.writeu8(buf, pos, sample_id)
-			return buf, pos + 1, size
+			return buf, pos + 1
 		end,
 		deserialize = function(buf: buffer, pos: number)
 			local id = buffer.readu8(buf, pos)

--- a/test/userdata.luau
+++ b/test/userdata.luau
@@ -12,8 +12,7 @@ local proxy = newproxy()
 local zero_proxy = newproxy()
 
 -- Check that userdata.luau works properly
-test.compare(test.newBuffer(UNSUPPORTED), test.inspect(userdata.unsupported))
-test.compare(false, isSupported(userdata.unsupported))
+test.compare(false, isSupported(proxy))
 
 local function reader(buf: buffer, pos: number): (unknown, number)
 	local id = buffer.readu8(buf, pos)
@@ -39,7 +38,7 @@ local obtainedBuffer, obtainedValue = test.inspect(proxy, {
 	disableValueComparison = true,
 })
 test.compare(test.newBuffer(UNSUPPORTED), obtainedBuffer)
-test.compare(userdata.unsupported, obtainedValue)
+test.compare(false, isSupported(obtainedValue))
 
 test.compare(test.newBuffer(CUSTOM, 0), test.inspect(zero_proxy))
 test.compare(true, isSupported(zero_proxy))


### PR DESCRIPTION
Ensures that users can differentiate between unsupported userdata, fixing the issues with `{ [userdata]: any }` producing a single key-value pair instead of the desired output.

Closes #126