### PR TITLE
Add existing passing between table deser

### DIFF
--- a/docs/spec/format.md
+++ b/docs/spec/format.md
@@ -36,6 +36,10 @@ The table size is not stored by default, see [extension support](../extension.md
 
 Vectors have multiple modes: scalar multiple, multi-set (byte, char, tryte), and set.  Scalar multiple vectors are multiples of the constant vectors, thus they can be stored in less bytes.  The intent behind multiple modes is primarily to produce smaller output sizes.  Vectors are basically numerical arrays of size 3, so two common cases (multi-set and set) were chosen to account for all cases and then special cases (scalar multiple) get a fast path with little cost.
 
+**What are duplicate values and how are they handled?**
+
+Duplicate values are those that reference the same object in memory (`foo[bar] == foo[baz] and bar == baz`).  In order to store duplicate values, most values must be doubly stored, with the exception of those resulting in small output sizes except empty tables.  Further calls to the internal `table.serialize` function which implements duplicate values results in continued support of prior duplicate values and will hold so long as the buffer remains the same (or uses the internal `inflate` function).
+
 ## Design
 
 | Tag(s)  | Cost     | Type       | Description                                 |

--- a/examples/extern/rose.luau
+++ b/examples/extern/rose.luau
@@ -60,7 +60,7 @@
 type SerialFormat = {
 	number -- class Index
 	| { any }? -- properties, w/o defaults
-	| { SerialFormat }? -- children
+	| { Instance }? -- children
 	| { [string]: any }? -- attributes
 }
 
@@ -130,13 +130,9 @@ function serialize_instance(obj: Instance)
 		props = nil
 	end
 
-	local children = {}
-	local child_pool = obj:GetChildren()
-	if #child_pool == 0 then
+	local children = obj:GetChildren()
+	if #children == 0 then
 		children = nil
-	end
-	for _, child in child_pool do
-		table.insert(children, serialize_instance(child))
 	end
 
 	local attributes = obj:GetAttributes()
@@ -170,7 +166,7 @@ function deserialize_instance(obj: SerialFormat, parent: Instance?)
 	local children = obj[3]
 	if children then
 		for _, child in children do
-			deserialize_instance(child, instance)
+			child.Parent = instance
 		end
 	end
 

--- a/src/inflate.luau
+++ b/src/inflate.luau
@@ -1,6 +1,8 @@
 --!optimize 2
 --!strict
 
+local existingBuffers = require("./link").existingBuffers
+
 local function inflateInternal(data: buffer, size: number)
 	if size <= buffer.len(data) then
 		return data
@@ -9,6 +11,9 @@ local function inflateInternal(data: buffer, size: number)
 	local newBuffer = buffer.create(size)
 
 	buffer.copy(newBuffer, 0, data)
+
+	existingBuffers[newBuffer] = existingBuffers[data]
+	existingBuffers[data] = nil
 
 	return newBuffer
 end

--- a/src/link.luau
+++ b/src/link.luau
@@ -68,4 +68,6 @@ function link.isduo(byte: number, type: SERIALIZABLE_TYPES): boolean
 		or type == "userdata" and byte >= USER_DUOSTART
 end
 
+link.existingBuffers = {} :: { [buffer]: unknown }
+
 return table.freeze(link)

--- a/src/table.luau
+++ b/src/table.luau
@@ -87,7 +87,8 @@ function tabSerializer(value: { [any]: any }, buf: buffer, pos: number)
 		end
 	end
 
-	local existingData: SerExisting = if existingBuffers[buf]
+	local isRoot = existingBuffers[buf] == nil
+	local existingData: SerExisting = if not isRoot
 		then existingBuffers[buf] :: SerExisting
 		else {
 			index = 1,
@@ -273,9 +274,11 @@ function tabSerializer(value: { [any]: any }, buf: buffer, pos: number)
 
 	serialTable(value)
 
-	table.clear(existing)
-	if roundRobinLength > 0 then
-		table.clear(roundRobinCache)
+	if isRoot then
+		table.clear(existing)
+		if roundRobinLength > 0 then
+			table.clear(roundRobinCache)
+		end
 	end
 
 	return buf, pos
@@ -320,7 +323,8 @@ function tabDeserializer(buf: buffer, pos: number)
 		end
 	end
 
-	local existingData = if existingBuffers[buf]
+	local isRoot = existingBuffers[buf] == nil
+	local existingData = if not isRoot
 		then existingBuffers[buf] :: DeserExisting
 		else {
 			index = 1,
@@ -513,7 +517,9 @@ function tabDeserializer(buf: buffer, pos: number)
 
 	local data = deserialTable(returnedTab)
 
-	table.clear(existing)
+	if isRoot then
+		table.clear(existing)
+	end
 
 	return data, pos
 end

--- a/src/table.luau
+++ b/src/table.luau
@@ -11,6 +11,22 @@ type Serialize = (data: any, buf: buffer, pos: number) -> (buffer, number)
 
 type Deserialize = (buf: buffer, pos: number) -> (any, number)
 
+type SerExisting = {
+	index: number,
+	data: { [any]: number },
+	-- round robin
+	rr_index: number,
+	rr_length: number,
+	rr_data: { [number]: any },
+}
+type DeserExisting = {
+	index: number,
+	data: { any },
+	-- round robin
+	rr_index: number,
+	paired: { any },
+}
+
 type Switch<VAR, F> = {
 	[VAR]: F,
 }
@@ -71,15 +87,15 @@ function tabSerializer(value: { [any]: any }, buf: buffer, pos: number)
 		end
 	end
 
-	local existingData = if existingBuffers[buf]
-		then existingBuffers[buf]
+	local existingData: SerExisting = if existingBuffers[buf]
+		then existingBuffers[buf] :: SerExisting
 		else {
 			index = 1,
-			data = { [value] = 0,
+			data = { [value] = 0 },
 			-- round robin
-			rr_data = {},
 			rr_length = 0,
 			rr_index = 61_440,
+			rr_data = {},
 		}
 
 	local existingIndex = existingData.index
@@ -141,20 +157,26 @@ function tabSerializer(value: { [any]: any }, buf: buffer, pos: number)
 
 			existingCache(data)
 
-			existingData.index = existingIndex
-			existingData.rr_length = roundRobinLength
-			existingData.rr_index = roundRobinIndex
-
 			serialTable(data)
 
-			existingIndex = existingData.index
-			roundRobinLength = existingData.rr_length
-			roundRobinIndex = existingData.rr_index
 			return
 		end
 
 		local oldPos = pos
+
+		if typeName == "userdata" then
+			existingData.index = existingIndex
+			existingData.rr_length = roundRobinLength
+			existingData.rr_index = roundRobinIndex
+		end
+
 		buf, pos = serialSwitch[typeName](data, buf, pos)
+
+		if typeName == "userdata" then
+			existingIndex = existingData.index
+			roundRobinLength = existingData.rr_length
+			roundRobinIndex = existingData.rr_index
+		end
 
 		if pos - oldPos > 2 and data == data then
 			existingCache(data)
@@ -299,7 +321,7 @@ function tabDeserializer(buf: buffer, pos: number)
 	end
 
 	local existingData = if existingBuffers[buf]
-		then existingBuffers[buf]
+		then existingBuffers[buf] :: DeserExisting
 		else {
 			index = 1,
 			data = { [0] = returnedTab },
@@ -307,6 +329,7 @@ function tabDeserializer(buf: buffer, pos: number)
 			rr_index = 61_440,
 			paired = {},
 		}
+
 	if existingBuffers[buf] == nil then
 		existingBuffers[buf] = existingData
 	end
@@ -343,13 +366,7 @@ function tabDeserializer(buf: buffer, pos: number)
 			local value = {}
 			existingCache(value)
 
-			existingData.index = existingIndex
-			existingData.rr_index = roundRobinIndex
-
 			deserialTable(value)
-
-			existingIndex = existingData.index
-			roundRobinIndex = existingData.rr_index
 
 			return value
 		end
@@ -379,7 +396,17 @@ function tabDeserializer(buf: buffer, pos: number)
 			return value
 		end
 
+		if case == "userdata" then
+			existingData.index = existingIndex
+			existingData.rr_index = roundRobinIndex
+		end
+
 		value, pos = deserialSwitch[case](buf, pos)
+
+		if case == "userdata" then
+			existingIndex = existingData.index
+			roundRobinIndex = existingData.rr_index
+		end
 
 		if pos - 2 > oldPos then
 			existingCache(value)

--- a/src/table.luau
+++ b/src/table.luau
@@ -298,10 +298,23 @@ function tabDeserializer(buf: buffer, pos: number)
 		end
 	end
 
-	local existingIndex = 1
-	local existing: { any } = { [0] = returnedTab }
-	local roundRobinIndex = 61_440
-	local paired = {}
+	local existingData = if existingBuffers[buf]
+		then existingBuffers[buf]
+		else {
+			index = 1,
+			data = { [0] = returnedTab },
+			-- round robin
+			rr_index = 61_440,
+			paired = {},
+		}
+	if existingBuffers[buf] == nil then
+		existingBuffers[buf] = existingData
+	end
+
+	local existingIndex = existingData.index
+	local existing: { any } = existingData.data
+	local roundRobinIndex = existingData.rr_index
+	local paired = existingData.paired
 
 	local deserialTable: (data: { [any]: any }) -> { [any]: any }
 
@@ -329,7 +342,16 @@ function tabDeserializer(buf: buffer, pos: number)
 		elseif valId == TABLE or valId == ARRAY or valId == DICT then
 			local value = {}
 			existingCache(value)
-			return deserialTable(value)
+
+			existingData.index = existingIndex
+			existingData.rr_index = roundRobinIndex
+
+			deserialTable(value)
+
+			existingIndex = existingData.index
+			roundRobinIndex = existingData.rr_index
+
+			return value
 		end
 
 		local value: any = nil

--- a/src/table.luau
+++ b/src/table.luau
@@ -279,6 +279,10 @@ function tabSerializer(value: { [any]: any }, buf: buffer, pos: number)
 		if roundRobinLength > 0 then
 			table.clear(roundRobinCache)
 		end
+	else
+		existingData.index = existingIndex
+		existingData.rr_length = roundRobinLength
+		existingData.rr_index = roundRobinIndex
 	end
 
 	return buf, pos
@@ -519,6 +523,9 @@ function tabDeserializer(buf: buffer, pos: number)
 
 	if isRoot then
 		table.clear(existing)
+	else
+		existingData.index = existingIndex
+		existingData.rr_index = roundRobinIndex
 	end
 
 	return data, pos

--- a/src/table.luau
+++ b/src/table.luau
@@ -5,6 +5,7 @@ local link = require("./link")
 local linkType = link.type
 local isLink = link.islink
 local isDuo = link.isduo
+local existingBuffers = link.existingBuffers
 
 type Serialize = (data: any, buf: buffer, pos: number) -> (buffer, number)
 
@@ -70,11 +71,22 @@ function tabSerializer(value: { [any]: any }, buf: buffer, pos: number)
 		end
 	end
 
-	local existingIndex = 1
-	local existing: { [any]: number } = { [value] = 0 }
-	local roundRobinCache: { [number]: any } = {}
-	local roundRobinLength = 0
-	local roundRobinIndex = 61440
+	local existingData = if existingBuffers[buf]
+		then existingBuffers[buf]
+		else {
+			index = 1,
+			data = { [value] = 0,
+			-- round robin
+			rr_data = {},
+			rr_length = 0,
+			rr_index = 61_440,
+		}
+
+	local existingIndex = existingData.index
+	local existing: { [any]: number } = existingData.data
+	local roundRobinCache: { [number]: any } = existingData.rr_data
+	local roundRobinLength = existingData.rr_length
+	local roundRobinIndex = existingData.rr_index
 
 	local serialTable: (data: { [any]: any }) -> ()
 
@@ -129,7 +141,15 @@ function tabSerializer(value: { [any]: any }, buf: buffer, pos: number)
 
 			existingCache(data)
 
+			existingData.index = existingIndex
+			existingData.rr_length = roundRobinLength
+			existingData.rr_index = roundRobinIndex
+
 			serialTable(data)
+
+			existingIndex = existingData.index
+			roundRobinLength = existingData.rr_length
+			roundRobinIndex = existingData.rr_index
 			return
 		end
 


### PR DESCRIPTION
Userdata now benefits from existing when trying to serialize tables, greatly reducing output size in some cases.

Closes #127