### PR TITLE
Fix empty table reference not kept

### DIFF
--- a/src/table.luau
+++ b/src/table.luau
@@ -113,6 +113,8 @@ function tabSerializer(value: { [any]: any }, buf: buffer, pos: number)
 			-- We will need to ensure the cycle is nonproblematic
 			-- Currently: Assumed improbable
 
+			existingCache(data)
+
 			do
 				local isEmpty = true
 				for _, _ in data :: { [any]: any } do
@@ -126,8 +128,6 @@ function tabSerializer(value: { [any]: any }, buf: buffer, pos: number)
 					return
 				end
 			end
-
-			existingCache(data)
 
 			serialTable(data)
 			return

--- a/src/table.luau
+++ b/src/table.luau
@@ -304,9 +304,10 @@ function tabDeserializer(buf: buffer, pos: number)
 	@native
 	local function deserialCache(valId: number): unknown
 		if valId == EMPTY then
+			local value = {}
 			pos += 1
 			existingCache(value)
-			return {}
+			return value
 		elseif valId == TABLE or valId == ARRAY or valId == DICT then
 			local value = {}
 			existingCache(value)

--- a/src/table.luau
+++ b/src/table.luau
@@ -305,6 +305,7 @@ function tabDeserializer(buf: buffer, pos: number)
 	local function deserialCache(valId: number): unknown
 		if valId == EMPTY then
 			pos += 1
+			existingCache(value)
 			return {}
 		elseif valId == TABLE or valId == ARRAY or valId == DICT then
 			local value = {}

--- a/test/table.luau
+++ b/test/table.luau
@@ -17,6 +17,10 @@ local TABLEEND = 200
 local recurse = {}
 recurse[1] = recurse
 
+local empty_ref = {}
+empty_ref[1] = {}
+empty_ref[2] = empty_ref[1]
+
 -- Check that table.luau works properly
 test.compare(test.newBuffer(EMPTY), test.inspect({}))
 test.compare(
@@ -30,6 +34,10 @@ test.compare(
 	test.inspect({ "bbb", "bbb" })
 )
 test.compare(test.newBuffer(ARRAY, EXIST, 0, 0, TABLEEND), test.inspect(recurse))
+test.compare(
+	test.newBuffer(ARRAY, EMPTY, EXIST, 1, 0, TABLEEND),
+	test.inspect(empty_ref)
+)
 
 -- error check
 local tabDeserialize = require("../src/table").deserialize


### PR DESCRIPTION
Empty tables should maintain their references when deserializing since it ensures correctness up to the specified limit (61440 then 4096).